### PR TITLE
Upload Ansible collection for Distil

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,11 @@
+---
+
+profile: production
+
+skip_list:
+  - name[template]
+  - var-naming[no-role-prefix]
+  - meta-runtime[unsupported-version]
+
+# exclude_paths:
+#   -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+name: test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.1
+
+  # ansible-galaxy:
+  #   runs-on: ubuntu-22.04
+  #   needs: pre-commit
+  #   steps:
+  #     - name: Checkout release
+  #       uses: actions/checkout@v4
+  #     - name: Test Ansible Galaxy collection build
+  #       uses: artis3n/ansible_galaxy_collection@v2
+  #       with:
+  #         api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+  #         publish: false
+
+  molecule:
+    runs-on: ubuntu-22.04
+    needs: pre-commit
+    # needs: ansible-galaxy
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - install
+          - upgrade
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Setup Docker Compose
+        uses: KengoTODA/actions-setup-docker-compose@v1
+        with:
+          version: "2.26.1"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install Python packages used for testing
+        run: python -m pip install -r requirements.txt
+        env:
+          FORCE_COLOR: "1"
+      - name: Run Molecule tests
+        run: molecule test --scenario-name ${{ matrix.scenario }}
+        env:
+          ANSIBLE_FORCE_COLOR: "True"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
 
@@ -42,17 +42,18 @@ jobs:
         scenario:
           - install
           - upgrade
+          - ssl_disable
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
       - name: Setup Docker Compose
         uses: KengoTODA/actions-setup-docker-compose@v1
         with:
-          version: "2.26.1"
+          version: "2.27.0"
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
           cache: pip
       - name: Install Python packages used for testing
         run: python -m pip install -r requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.retry
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.retry
 .vscode
+.venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+---
+# .pre-commit-config.yaml
+# Pre-commit hook tasks.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+      - id: detect-private-key
+      - id: check-added-large-files
+      - id: check-merge-conflict
+  - repo: https://github.com/crate-ci/typos.git
+    rev: v1.21.0
+    hooks:
+      - id: typos
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/ansible-community/ansible-lint.git
+    rev: v24.5.0
+    hooks:
+      - id: ansible-lint
+  - repo: https://github.com/ansible-community/antsibull-changelog.git
+    rev: 0.27.0
+    hooks:
+      - id: antsibull-changelog-lint
+      - id: antsibull-changelog-lint-changelog-yaml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+---
+
+ignore:
+  - changelogs
+  - roles/base/files/meter_mappings.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Catalystcloud\.Distil Release Notes
+
+**Topics**
+
+- <a href="#v1-0-0">v1\.0\.0</a>
+    - <a href="#release-summary">Release Summary</a>
+
+<a id="v1-0-0"></a>
+## v1\.0\.0
+
+<a id="release-summary"></a>
+### Release Summary
+
+Initial release of the Ansible collection for OpenStack Distil\.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+==================================
+Catalystcloud.Distil Release Notes
+==================================
+
+.. contents:: Topics
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+Initial release of the Ansible collection for OpenStack Distil.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ make sure the target hosts have at least one of the above groups assigned to it.
         * The Keystone project `created_on` field, if it is available. This field is set by Adjutant when it creates new projects on sign-ups. This is usually the newest, and thus the most likely to be used.
         * The oldest found `last_collected` value for the existing projects being serviced by this collector instance. If Keystone is used to create the project directly (and not via Adjutant), this is the one that will likely be used.
         * The maximum `last_collected` value for the current time, which is calculated from `distil_collector_max_collection_start_age`. The default value is 36 days, to allow for at least one month's worth of billing to be caught up if required. This serves as the fallback for when no better alternative is found, as it means the collector will spend some time catching up the project to the present.
+* `distil_collector_exporter_port` - The default port for Distil Collector Exporter. When using multiple collectors on the same host, define unique ports for each individual collector. Default is `16799`.
 
 #### Distil database configuration
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The following process is undertaken when upgrading:
 1. Upgrade Distil API, Distil Exporter and Distil Collector on all nodes.
 1. Migrate the Distil database.
     * The database migration is only performed once, on the first node to be upgraded.
-1. Restart Distil API, Distil Exporter and Distil Collector on all nodes
+1. Restart Distil API, Distil Exporter and Distil Collector on all nodes.
 
 **Take care when using this playbook, as Distil is completely shutdown while upgrading.**
 **This results in a short Distil API outage (affecting the billing dashboard customers use).**

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ make sure the target hosts have at least one of the above groups assigned to it.
 
 #### Distil common configuration
 
+* `distil_base_dir` - The base directory under which Distil service files will be installed. Default is `/opt/distil`.
+* `distil_config_dir` - The host directory to install Distil configuration files to. Default is `{{ distil_base_dir }}/etc`.
+* `distil_lib_dir` - The host directory to use for Distil runtime files. Default is `{{ distil_base_dir }}/lib`.
+* `distil_log_dir` - The target directory for Distil service log files on the host. Default is `/var/log/distil`.
 * `distil_ssl_cert` - Service SSL certificate filepath on the host.
 * `distil_ssl_key` - Service SSL private key filepath on the host.
 * `distil_ssl_cacert` - Service CA certificate bundle filepath on the host.

--- a/README.md
+++ b/README.md
@@ -218,16 +218,22 @@ that do not require a database migration, use the
 Start all Distil services on all nodes, and ensure they are configured to start automatically when the node restarts.
 
 * `catalystcloud.distil.enable_api` - Enable only Distil API
-* `catalystcloud.distil.enable_manage` - Enable only Distil Manage
 * `catalystcloud.distil.enable_exporter` - Enable only Distil Exporter
 * `catalystcloud.distil.enable_collector` - Enable only Distil Collector
+
+### `catalystcloud.distil.stop`
+
+Temporarily stop all Distil services on all nodes, without disabling startup on next boot.
+
+* `catalystcloud.distil.stop_api` - Stop only Distil API
+* `catalystcloud.distil.stop_exporter` - Stop only Distil Exporter
+* `catalystcloud.distil.stop_collector` - Stop only Distil Collector
 
 ### `catalystcloud.distil.disable`
 
 Stop all Distil services on all nodes, and ensure they do not restart if the node restarts.
 
 * `catalystcloud.distil.disable_api` - Disable only Distil API
-* `catalystcloud.distil.disable_manage` - Disable only Distil Manage
 * `catalystcloud.distil.disable_exporter` - Disable only Distil Exporter
 * `catalystcloud.distil.disable_collector` - Disable only Distil Collector
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,339 @@
+# Ansible collection for OpenStack Distil
+
+[![GitHub License](https://img.shields.io/github/license/catalyst-cloud/ansible-collection-distil)](https://github.com/catalyst-cloud/ansible-collection-distil/blob/main/LICENSE) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/catalyst-cloud/ansible-collection-distil/test.yml?label=tests)](https://github.com/catalyst-cloud/ansible-collection-distil/actions/workflows/test.yml)
+
+This is an example Ansible collection for deploying the Distil rating service
+to an OpenStack control plane.
+
+The various Distil services are run inside Docker containers,
+managed by Docker Compose V2.
+
+## Installation
+
+To install this collection in your Ansible environment, you can create a `requirements.yml`
+file with the following contents, or add the contents to an existing `requirements.yml` file.
+Make sure to substitute `<git ref>` for the latest tagged version,
+or the desired development branch name.
+
+```yaml
+collections:
+  - name: https://github.com/catalyst-cloud/ansible-collection-distil.git
+    version: "<git ref>"
+    type: git
+```
+
+The collection will then be installed when `ansible-galaxy install -r requirements.yml` is run.
+
+## Usage
+
+### Inventory
+
+To use this collection, inventory variables need to be defined for the managed host groups.
+
+When using the built-in Ansible playbooks (optional), the following host groups are used:
+
+* `distil` - Host group for installing **all** available Distil services
+* `distil_api` - Host froup for installing Distil API only
+* `distil_manage` - Host froup for installing Distil Manage only
+* `distil_exporter` - Host froup for installing Distil Exporter only
+* `distil_collector` - Host froup for installing Distil Collector only
+
+If you are making use of the Ansible playbooks bundled within this playbook to manage Distil,
+make sure the target hosts have at least one of the above groups assigned to it.
+
+#### Distil common configuration
+
+* `distil_ssl_cert` - Service SSL certificate filepath on the host.
+* `distil_ssl_key` - Service SSL private key filepath on the host.
+* `distil_ssl_cacert` - Service CA certificate bundle filepath on the host.
+* `distil_openstack_region` - The name of the OpenStack region being deployed to. Distil must be deployed separately to all regions.
+* `distil_user_name` - Distil service user name. Default is `distil`.
+* `distil_user_group` - Distil service group name. Default is `distil`.
+* `distil_user_uid` - UID for the created service user. **Must be unique**. Default is `305`.
+* `distil_user_gid` - GID for the created service group. **Must be unique**. Default is `305`.
+* `distil_user_groups` - A list of additional groups to assign to the service user (if required). Default is to assign no additional groups.
+* `distil_timezone` - The operating timezone for the Distil services. As billing itself is always processed in UTC, this mainly effects logging. Default is `Etc/UTC`.
+* `distil_erp_driver` - The ERP driver to use for invoice and quotation handling in Distil API.
+    * Supported values are:
+        * `jsonfile` (default)
+        * `odoo`
+    * Make sure to configure the selected ERP driver using the appropriate variables below.
+
+#### Distil Keystone configuration
+
+* `distil_keystone_enable` - Enable installation and configuration of service resources in Keystone. Default is `true`.
+* `distil_keystone_auth_url` - Auth URL for the Keystone service in the OpenStack region.
+    * This is used as the endpoint for Keystone authentication in Distil.
+    * Define as the base URL without the version endpoint, e.g. `https://keystone.example.com:5000`.
+* `distil_keystone_auth_version` - Keystone API endpoint version to use for authentication. Default is `v3`.
+* `distil_keystone_user_name` - Service username in Keystone. Default is `distil`.
+* `distil_keystone_user_password` - Password for the service user in Keystone. Should be defined in Ansible Vault.
+* `distil_keystone_user_email` - Email address for the service user in Keystone. Default is `distil@localhost`.
+* `distil_keystone_user_project` - The name of the default project for the service user in Keystone (and the service project to use in the service configuration). Default is `services`.
+* `distil_keystone_user_domain` - The name of the default domain for the service user in Keystone. Default is `Default`.
+* `distil_keystone_ansible_auth_cloud` - Optional variable for explicitly provided credentials to authenticate with Keystone in the target region, so Ansible can create service resources. Useful in CI environments. Default is to auto-fetch session environment variables defined in the Ansible controller's environment.
+
+#### Distil API configuration
+
+* `distil_api_hostname` - Hostname for Distil API that clients should use.
+    * This is used to configure the service endpoints in Keystone.
+* `distil_api_port` - Bind port for Distil API. Default is `9999`.
+* `distil_api_ignore_products_in_quotations` - List of products (services) to remove from quotations. Useful for hiding services that are being collected by Distil, but not yet charged. Default is to not remove any products.
+
+#### Distil Exporter configuration
+
+* `distil_exporter_port` - Bind port for Distil Exporter. Default is `16798`.
+
+#### Distil Collector configuration
+
+* `distil_collectors` - Configuration for what collectors to create and run. For more information on how to define this, refer to the `catalystcloud.distil.collector` role inventory defaults file. Default is to create a single collector (the default collector) that collects **all** existing domains and projects.
+* `distil_collector_periodic_interval` - The interval at which Distil Collector carries out usage collection jobs, in seconds. Default is `3600` (collect once every hour).
+* `distil_collector_collect_window` - The amount of usage Distil should collect at a time (per window), in hours. Default is `1` (collect in 1 hour windows).
+* `distil_collector_max_windows_per_cycle` - The maximum amount of windows Distil should collect for a project per collection run. Default is `12` (collect up to 12 windows).
+* `distil_collector_max_collection_start_age` - The maximum time period for determining the start time for usage collection on a new project, in hours. Default is `864` hours (36 days).
+    * Whenever a new project is collected by Distil, it uses the latest (newest) of three possible values:
+        * The Keystone project `created_on` field, if it is available. This field is set by Adjutant when it creates new projects on sign-ups. This is usually the newest, and thus the most likely to be used.
+        * The oldest found `last_collected` value for the existing projects being serviced by this collector instance. If Keystone is used to create the project directly (and not via Adjutant), this is the one that will likely be used.
+        * The maximum `last_collected` value for the current time, which is calculated from `distil_collector_max_collection_start_age`. The default value is 36 days, to allow for at least one month's worth of billing to be caught up if required. This serves as the fallback for when no better alternative is found, as it means the collector will spend some time catching up the project to the present.
+
+#### Distil database configuration
+
+* `distil_database_flavor` - The type of database storage backend to use. Default is `mysql`.
+* `distil_database_library` - The library to use to interface with the database. Default is `pymysql`.
+* `distil_database_hosts` - A list of database servers (in `<hostname-or-IP>:<port>` format) to connect to.
+* `distil_database_username` - Service username in the database.
+* `distil_database_password` - Password for the service user in the database. Should be defined in Ansible Vault.
+* `distil_database_name` - Name of the service database. Default is `distil`.
+
+#### Distil JSON file configuration
+
+Ensure these options are configured when using the `jsonfile` ERP driver.
+
+* `distil_jsonfile_tax_rate` - The tax rate to use when calculating, as a decimal percentage. Default is `0` (no tax).
+
+#### Distil Odoo configuration
+
+Ensure these options are configured when using the `odoo` ERP driver.
+
+* `distil_odoo_version` - Version of the Odoo server. Set to `null` to auto-detect the server version. Default is `null`.
+* `distil_odoo_hostname` - Hostname of the Odoo server.
+* `distil_odoo_port` - Listening port of the Odoo driver. Default is `8069`.
+* `distil_odoo_protocol` - Odoo protocol to use. Use `jsonrpc+ssl` for HTTPS. Default is `jsonrpc` (for HTTP).
+* `distil_odoo_database` - Odoo database to load.
+* `distil_odoo_username` - Username of the Odoo user to authenticate as.
+* `distil_odoo_password` - Password for the Odoo user.
+    * Should be defined either in Hiera eyaml or Ansible Vault.
+* `distil_odoo_licensed_os_distros` - List of OS distros in Nova to treat as "licensed" for billing purposes. Default is empty.
+* `distil_odoo_extra_product_categories` - List of product categories listed in Odoo (that Distil does not check by default). Default is set to the following:
+  ```yaml
+  distil_odoo_extra_product_categories:
+    - "Database"
+    - "COE"
+  ```
+* `distil_odoo_invisible_products` - List of product IDs that should be hidden from invoices when user query the Distil API. Default is empty.
+
+## Playbooks
+
+To run a Distil collection playbook from another playbook, import it into your playbook using
+[`ansible.builtin.import_playbook`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_playbook_module.html).
+
+```yaml
+---
+
+- name: Deploy Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.deploy
+```
+
+### `catalystcloud.distil.deploy`
+
+Deploy all Distil services to all nodes.
+
+This is the standard playbook to be used for releases.
+It also can be used to install Distil on a new node in a region where Distil is already running.
+
+This playbook deploys Distil one-by-one on each host, ensuring there is little to no downtime
+of the service for API access and billing.
+Deploys are idempotent, and services are only restarted on a host if the service was updated.
+
+**Do not use this playbook when a database migration of Distil is required.**
+**Database migrations are NOT performed by this playbook.**
+**Use the [`catalystcloud.distil.upgrade`](#catalystclouddistilupgrade) playbook**
+**for version upgrades of Distil.**
+
+Related playbooks:
+
+* `catalystcloud.distil.deploy_api` - Deploy only Distil API
+* `catalystcloud.distil.deploy_manage` - Deploy only Distil Manage
+* `catalystcloud.distil.deploy_exporter` - Deploy only Distil Exporter
+* `catalystcloud.distil.deploy_collector` - Deploy only Distil Collector
+
+### `catalystcloud.distil.upgrade`
+
+Upgrade all Distil services on all nodes.
+
+This playbook serves two main purposes:
+
+* Upgrading Distil in an existing region when a database migration is required (e.g. version upgrade).
+* Bootstrap a new installation of Distil in a new region.
+
+The following process is undertaken when upgrading:
+
+1. Stop and disable all Distil services on all nodes, to ensure the database is not being used during migration.
+1. Upgrade the Distil service resources on OpenStack (e.g. Keystone).
+1. Upgrade Distil API, Distil Exporter and Distil Collector on all nodes.
+1. Migrate the Distil database.
+    * The database migration is only performed once, on the first node to be upgraded.
+1. Restart Distil API, Distil Exporter and Distil Collector on all nodes
+
+**Take care when using this playbook, as Distil is completely shutdown while upgrading.**
+**This results in a short Distil API outage (affecting the billing dashboard customers use).**
+**Distil Collector may also fall behind on collection if the outage is for an extended period.**
+
+If Distil is not changed in the release, or the upgrade is limited to changes
+that do not require a database migration, use the
+[`catalystcloud.distil.deploy`](#catalystclouddistildeploy) playbook.
+
+### `catalystcloud.distil.enable`
+
+Start all Distil services on all nodes, and ensure they are configured to start automatically when the node restarts.
+
+* `catalystcloud.distil.enable_api` - Enable only Distil API
+* `catalystcloud.distil.enable_manage` - Enable only Distil Manage
+* `catalystcloud.distil.enable_exporter` - Enable only Distil Exporter
+* `catalystcloud.distil.enable_collector` - Enable only Distil Collector
+
+### `catalystcloud.distil.disable`
+
+Stop all Distil services on all nodes, and ensure they do not restart if the node restarts.
+
+* `catalystcloud.distil.disable_api` - Disable only Distil API
+* `catalystcloud.distil.disable_manage` - Disable only Distil Manage
+* `catalystcloud.distil.disable_exporter` - Disable only Distil Exporter
+* `catalystcloud.distil.disable_collector` - Disable only Distil Collector
+
+### `catalystcloud.distil.decommission`
+
+Completely uninstall all Distil services from all nodes, and remove service files.
+
+Related playbooks (note that these will not remove the base service files, only service-specific files):
+
+* `catalystcloud.distil.decommission_api` - Decommission only Distil API
+* `catalystcloud.distil.decommission_manage` - Decommission only Distil Manage
+* `catalystcloud.distil.decommission_exporter` - Decommission only Distil Exporter
+* `catalystcloud.distil.decommission_collector` - Decommission only Distil Collector
+
+### Other playbooks
+
+The following additional playbooks are also available, but are generally not intended to be used for regular releases.
+
+These playbooks are used internally by other playbooks.
+
+#### `catalystcloud.distil.install`
+
+Install all Distil service files to all nodes.
+
+Differs from `deploy` and `upgrade` by simply installing/updating the service files, without managing running services.
+
+Related playbooks:
+
+* `catalystcloud.distil.install_base` - Install only Distil base services files
+* `catalystcloud.distil.install_api` - Install only Distil API
+* `catalystcloud.distil.install_manage` - Install only Distil Manage
+* `catalystcloud.distil.install_exporter` - Install only Distil Exporter
+* `catalystcloud.distil.install_collector` - Install only Distil Collector
+
+#### `catalystcloud.distil.uninstall`
+
+Remove all Distil service files from all nodes.
+
+Used as the service uninstallation step in the [`catalystcloud.distil.decommission`](#catalystclouddistildecommission) playbooks.
+
+Related playbooks:
+
+* `catalystcloud.distil.install_base` - Uninstall only Distil base services files
+* `catalystcloud.distil.install_api` - Uninstall only Distil API
+* `catalystcloud.distil.install_manage` - Uninstall only Distil Manage
+* `catalystcloud.distil.install_exporter` - Uninstall only Distil Exporter
+* `catalystcloud.distil.install_collector` - Uninstall only Distil Collector
+
+#### `catalystcloud.distil.predeploy`
+
+Run pre-deploy tasks on all nodes.
+
+Usually used for shutting down old versions of services.
+
+Run as part of the the [`catalystcloud.distil.deploy`](#catalystclouddistildeploy) and [`catalystcloud.distil.upgrade`](#catalystclouddistilupgrade) playbooks.
+
+Related playbooks:
+
+* `catalystcloud.distil.predeploy_base` - Run pre-deploy tasks only for Distil base services files
+* `catalystcloud.distil.predeploy_api` - Run pre-deploy tasks only for Distil API
+* `catalystcloud.distil.predeploy_manage` - Run pre-deploy tasks only for Distil Manage
+* `catalystcloud.distil.predeploy_exporter` - Run pre-deploy tasks only for Distil Exporter
+* `catalystcloud.distil.predeploy_collector` - Run pre-deploy tasks only for Distil Collector
+
+#### `catalystcloud.distil.postdeploy`
+
+Run post-deploy tasks on all nodes.
+
+Usually used for cleaning up old service files.
+
+Run as part of the the [`catalystcloud.distil.deploy`](#catalystclouddistildeploy) and [`catalystcloud.distil.upgrade`](#catalystclouddistilupgrade) playbooks.
+
+Related playbooks:
+
+* `catalystcloud.distil.postdeploy_base` - Run post-deploy tasks only for Distil base services files
+* `catalystcloud.distil.postdeploy_api` - Run post-deploy tasks only for Distil API
+* `catalystcloud.distil.postdeploy_manage` - Run post-deploy tasks only for Distil Manage
+* `catalystcloud.distil.postdeploy_exporter` - Run post-deploy tasks only for Distil Exporter
+* `catalystcloud.distil.postdeploy_collector` - Run post-deploy tasks only for Distil Collector
+
+## Roles
+
+### Main Roles
+
+The following main roles are available for general use to manage the main Distil services.
+
+* `catalystcloud.distil.base` - Manage Distil base files (common to all services).
+* `catalystcloud.distil.api` - Manage Distil API.
+* `catalystcloud.distil.manage` - Manage Distil Manage.
+* `catalystcloud.distil.exporter` - Manage Distil Exporter.
+* `catalystcloud.distil.collector` - Manage Distil Collector.
+* `catalystcloud.distil.keystone` - Manage Distil service resources in Keystone.
+
+By default, these roles will install/update and start the relevant service,
+restarting running services if there were changes.
+
+They also contain additional tasks used for other purposes,
+which can be run using the
+[`ansible.builtin.include_role`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_role_module.html)
+module and the `tasks_from` parameter:
+
+* `predeploy` - Run pre-deploy tasks (usually used for shutting down old versions of services)
+* `install` - Install the service onto the host (update if already installed)
+* `enable` - Enable and start the service on the host (if not already enabled and running)
+* `stop` - Stop the service on the host (if running), without disabling running on startup
+* `disable` - Stop and disable the service on the host (if not already stopped and disabled)
+* `uninstall` - Uninstall the service from the host (if not already uninstalled)
+* `postdeploy` - Run post-deploy tasks (usually used for cleaning up old service files)
+
+Some roles have additional tasks available for specific purposes.
+
+* The `catalystcloud.distil.keystone` role contains an `authenticate` task for authentication with Keystone in the target region.
+* The `catalystcloud.distil.manage` role contains a `migrate` role for migrating the Distil database.
+
+### Other Roles
+
+The following roles are also available in this collection, but not intended to be used under normal circumstances.
+
+* `catalystcloud.distil.common` - Provides defaults for common variables.
+    * Called internally by the main roles, so this role should not be used directly.
+
+## Testing
+
+This repository contains [pre-commit hooks](https://pre-commit.com) for linting purposes,
+and a [Molecule](https://ansible.readthedocs.io/projects/molecule) test suite for
+running the collection and verifying the results are correct.
+
+Both of them are run automatically using GitHub Actions for pull requests
+and the `main` branch.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ The following service files are installed by the collection:
     * `distil.conf` - Collector-specific service configuration (mounted as `/etc/distil/distil.conf`)
     * `README.md` - Useful information for interacting with the service
 * `/var/log/distil` - Logging directory for Distil on the host (configurable)
+  * `distil-db-manage.log` - Distil DB Manage run log
+  * `distil-api.log` - Distil API daemon log
+  * `distil-api-wsgi.log` - Distil API uWSGI service log
+  * `distil-exporter.log` - Distil Exporter daemon log
+  * `distil-exporter-wsgi.log` - Distil API uWSGI service log
+  * `distil-collector[-<name>].log` - Distil Collector daemon logs (separate for each collector type)
 * `/etc/logrotate.d/distil-logs` - Logrotate configuration for the Distil logging directory
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The following service files are installed by the collection:
     * `meter_mappings.yaml` - Ceilometer meter -> Distil serving mapping configuration
     * `transformer.yaml` - Distil transformer configuration (for transformers used in meter mappings)
     * `policy.yaml` - Keystone policy file for Distil API
-    * `products.json` - JSON products for the Distil `jsonfile` ERP driver
+    * `products.json` - JSON products file for the Distil `jsonfile` ERP driver
   * `lib/` - Runtime file directory (mounted as `/var/lib/distil`, not normally used)
   * `manage/` - Distil Manage
     * `docker-compose.yml` - Service compose file

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ make sure the target hosts have at least one of the above groups assigned to it.
 * `distil_config_dir` - The host directory to install Distil configuration files to. Default is `{{ distil_base_dir }}/etc`.
 * `distil_lib_dir` - The host directory to use for Distil runtime files. Default is `{{ distil_base_dir }}/lib`.
 * `distil_log_dir` - The target directory for Distil service log files on the host. Default is `/var/log/distil`.
+* `distil_docker_group` - The group to assign to directories that need to be accessible by users who can use Docker. Default is `root`.
+* `distil_log_group` - The group to assign to the logging directory. Default is to assign the Distil service group.
 * `distil_ssl_cert` - Service SSL certificate filepath on the host.
 * `distil_ssl_key` - Service SSL private key filepath on the host.
 * `distil_ssl_cacert` - Service CA certificate bundle filepath on the host.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ using the `openstack rating` commands provided by the
 [`python-distilclient`](https://pypi.org/project/python-distilclient) package,
 or via the dashboard using the [Distil UI](https://opendev.org/x/distil-ui) plugin for Horizon.
 
+Distil API uses a configurable ERP driver for a number of functions:
+
+* Querying for invoices from previous months
+* Fetching a list of products with prices, for generating the current month's quotations
+
+The Ansible collection configures Distil to use the `jsonfile` ERP driver by default.
+This reads a list of products and prices from a `products.json` that is installed
+with the configuration, and allows Distil to work in test environments without a functioning
+Odoo installation.
+
+To use Distil with Odoo, the ERP driver will need to be changed to `odoo` using the inventory,
+as documented below.
+
 By default, a service container named `distil-api` will be created on the host.
 
 Distil API is run as a WSGI app within [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest),
@@ -147,6 +160,7 @@ The following service files are installed by the collection:
     * `meter_mappings.yaml` - Ceilometer meter -> Distil serving mapping configuration
     * `transformer.yaml` - Distil transformer configuration (for transformers used in meter mappings)
     * `policy.yaml` - Keystone policy file for Distil API
+    * `products.json` - JSON products for the Distil `jsonfile` ERP driver
   * `lib/` - Runtime file directory (mounted as `/var/lib/distil`, not normally used)
   * `manage/` - Distil Manage
     * `docker-compose.yml` - Service compose file

--- a/README.md
+++ b/README.md
@@ -212,9 +212,13 @@ make sure the target hosts have at least one of the above groups assigned to it.
 * `distil_log_dir` - The target directory for Distil service log files on the host. Default is `/var/log/distil`.
 * `distil_log_dir_group` - The group to assign to the logging directory. Default is to assign the Distil service group.
 * `distil_log_dir_mode` - The permissions for the logging directory. Default is `"0750"`.
-* `distil_ssl_cert` - Service SSL certificate filepath on the host.
-* `distil_ssl_key` - Service SSL private key filepath on the host.
-* `distil_ssl_cacert` - Service CA certificate bundle filepath on the host.
+* `distil_ssl_enable` - Whether or not public-facing Distil services should use SSL encryption. Default is `true`.
+  * When running Distil in a testing environment, disabling this makes testing easier, as you do not need to setup certificates.
+  * When enabled, the `distil_ssl_cert` and `distil_ssl_key` variables also need to be set.
+  * **For a production deployment, to facilitate end-to-end encrypted traffic, it is recommended that this option is enabled.**
+* `distil_ssl_cert` - Service SSL certificate filepath on the host. Required if `distil_ssl_enable` is enabled.
+* `distil_ssl_key` - Service SSL private key filepath on the host. Required if `distil_ssl_enable` is enabled.
+* `distil_ssl_cacert` - Service CA certificate bundle filepath on the host. Default is `/etc/ssl/certs/ca-certificates.crt`.
 * `distil_openstack_region` - The name of the OpenStack region being deployed to. Distil must be deployed individually to all regions.
 * `distil_user_name` - Distil service user name. Default is `distil`.
 * `distil_user_group` - Distil service group name. Default is `distil`.
@@ -247,15 +251,21 @@ make sure the target hosts have at least one of the above groups assigned to it.
 * `distil_api_hostname` - Hostname for Distil API that clients should use.
     * This is used to configure the service endpoints in Keystone.
 * `distil_api_port` - Bind port for Distil API. Default is `9999`.
+* `distil_api_ssl_enable` - Bind Distil API to an SSL (HTTPS) port. Default is to use the value set in `distil_ssl_enable`.
+* `distil_api_ssl_cert` - SSL certificate location on the host for Distil API. Default is to use the value set in `distil_ssl_cert`.
+* `distil_api_ssl_key` - SSL private key location on the host for Distil API. Default is to use the value set in `distil_ssl_key`.
+* `distil_api_ssl_cacert` - CA certificate location on the host for Distil API. Default is to use the value set in `distil_ssl_cacert`.
 * `distil_api_ignore_products_in_quotations` - List of products (services) to remove from quotations. Useful for hiding services that are being collected by Distil, but not yet charged. Default is to not remove any products.
 
 #### Distil Exporter configuration
 
 * `distil_exporter_port` - Bind port for Distil Exporter. Default is `16798`.
+* `distil_exporter_ssl_cacert` - CA certificate location on the host for Distil Exporter. Default is to use the value set in `distil_ssl_cacert`.
 
 #### Distil Collector configuration
 
 * `distil_collectors` - Configuration for what collectors to create and run. For more information on how to define this, refer to the `catalystcloud.distil.collector` role inventory defaults file. Default is to create a single collector (the default collector) that collects **all** existing domains and projects.
+* `distil_collector_ssl_cacert` - CA certificate location on the host for Distil Collector. Default is to use the value set in `distil_ssl_cacert`.
 * `distil_collector_periodic_interval` - The interval at which Distil Collector carries out usage collection jobs, in seconds. Default is `3600` (collect once every hour).
 * `distil_collector_collect_window` - The amount of usage Distil should collect at a time (per window), in hours. Default is `1` (collect in 1 hour windows).
 * `distil_collector_max_windows_per_cycle` - The maximum amount of windows Distil should collect for a project per collection run. Default is `12` (collect up to 12 windows).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Docker Compose V2 is used to manage the lifecycle of the containers.
 
 A set of service containers used for administration of Distil.
 
-Current the only available container is `distil-db-manage`, which is used primarily
+Currently the only available container is `distil-db-manage`, which is used primarily
 to initialise the Distil database on new installations, and database migrations
 when performing service upgrades.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,16 @@ Ensure these options are configured when using the `odoo` ERP driver.
 
 ## Playbooks
 
-To run a Distil collection playbook from another playbook, import it into your playbook using
+Once the collection has been installed, the playbooks documented below can be run
+from the command line using the `ansible-playbook` command.
+
+```bash
+ansible-playbook -i <path-to-inventory> catalystcloud.distil.deploy
+```
+
+You can also optionally use `--limit` to run playbooks on specific hosts.
+
+To run a Distil collection playbook from inside another playbook, import it into your playbook using
 [`ansible.builtin.import_playbook`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/import_playbook_module.html).
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ make sure the target hosts have at least one of the above groups assigned to it.
 Ensure these options are configured when using the `jsonfile` ERP driver.
 
 * `distil_jsonfile_tax_rate` - The tax rate to use when calculating, as a decimal percentage. Default is `0` (no tax).
+* `distil_jsonfile_regions` - A list of regions available in this OpenStack environment to generate product metadata for. Default is to configure only the region set in `distil_openstack_region`.
 
 #### Distil Odoo configuration
 

--- a/README.md
+++ b/README.md
@@ -362,9 +362,53 @@ The following roles are also available in this collection, but not intended to b
 
 ## Testing
 
-This repository contains [pre-commit hooks](https://pre-commit.com) for linting purposes,
-and a [Molecule](https://ansible.readthedocs.io/projects/molecule) test suite for
-running the collection and verifying the results are correct.
+This repository contains pre-commit hooks for linting purposes,
+and a Molecule test suite for running the collection and verifying the results are correct.
 
-Both of them are run automatically using GitHub Actions for pull requests
-and the `main` branch.
+Both of them are run automatically using GitHub Actions for pull requests and the `main` branch.
+
+Due to using the latest versions of the related Ansible tools
+(and their Python version requirements), Python 3.10 or later is required to run them.
+
+### Pre-commit hooks
+
+To run these locally on your system, make sure [`pre-commit`](https://pre-commit.com) is installed,
+and the command is executable from your `PATH`.
+
+Run the pre-commit hooks automatically on each commit:
+
+```bash
+pre-commit install
+```
+
+Manually run the pre-commit hooks:
+
+```bash
+pre-commit run --all-files
+```
+
+### Molecule tests
+
+The [Molecule](https://ansible.readthedocs.io/projects/molecule) tests run
+using the `delegated` driver targeted at `localhost`.
+This is designed to be run on GitHub Actions, but can be also run
+on a local machine (e.g. an OpenStack instance) for testing purposes.
+
+First, create a virtualenv, source it and install the packages defined in `requirements.txt`:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+Once that is done, you should be able to use the `molecule` command to run tests.
+
+There are two test scenarios:
+
+* `install` - Test the playbooks for the standard deploy of Distil to a region where it is already running.
+* `upgrade` - Test the playbooks for version upgrades (and also deploying Distil to a new region).
+
+```bash
+molecule test --scenario-name <scenario-name>
+```

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ make sure the target hosts have at least one of the above groups assigned to it.
 * `distil_keystone_user_domain` - The name of the default domain for the service user in Keystone. Default is `Default`.
 * `distil_keystone_ansible_auth_cloud` - Optional variable for explicitly provided credentials to authenticate with Keystone in the target region, so Ansible can create service resources. Useful in CI environments. Default is to auto-fetch session environment variables defined in the Ansible controller's environment.
 
+#### Distil Manage configuration
+
+* `distil_manage_ssl_cacert` - CA certificate location on the host for Distil Manage. Default is to use the value set in `distil_ssl_cacert`.
+
 #### Distil API configuration
 
 * `distil_api_hostname` - Hostname for Distil API that clients should use.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The following service files are installed by the collection:
   * `distil-api.log` - Distil API daemon log
   * `distil-api-wsgi.log` - Distil API uWSGI service log
   * `distil-exporter.log` - Distil Exporter daemon log
-  * `distil-exporter-wsgi.log` - Distil API uWSGI service log
+  * `distil-exporter-wsgi.log` - Distil Exporter uWSGI service log
   * `distil-collector[-<name>].log` - Distil Collector daemon logs (separate for each collector type)
 * `/etc/logrotate.d/distil-logs` - Logrotate configuration for the Distil logging directory
 

--- a/README.md
+++ b/README.md
@@ -162,10 +162,11 @@ Deploys are idempotent, and services are only restarted on a host if the service
 
 Related playbooks:
 
-* `catalystcloud.distil.deploy_api` - Deploy only Distil API
-* `catalystcloud.distil.deploy_manage` - Deploy only Distil Manage
-* `catalystcloud.distil.deploy_exporter` - Deploy only Distil Exporter
-* `catalystcloud.distil.deploy_collector` - Deploy only Distil Collector
+* `catalystcloud.distil.deploy_distil` - Deploy Distil (to nodes with all services installed, not service-specific nodes)
+* `catalystcloud.distil.deploy_api` - Deploy Distil API (to dedicated nodes only)
+* `catalystcloud.distil.deploy_manage` - Deploy Distil Manage (to dedicated nodes only)
+* `catalystcloud.distil.deploy_exporter` - Deploy Distil Exporter (to dedicated nodes only)
+* `catalystcloud.distil.deploy_collector` - Deploy Distil Collector (to dedicated nodes only)
 
 ### `catalystcloud.distil.upgrade`
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ To use this collection, inventory variables need to be defined for the managed h
 When using the built-in Ansible playbooks (optional), the following host groups are used:
 
 * `distil` - Host group for installing **all** available Distil services
-* `distil_api` - Host froup for installing Distil API only
-* `distil_manage` - Host froup for installing Distil Manage only
-* `distil_exporter` - Host froup for installing Distil Exporter only
-* `distil_collector` - Host froup for installing Distil Collector only
+* `distil_api` - Host group for installing Distil API only
+* `distil_manage` - Host group for installing Distil Manage only
+* `distil_exporter` - Host group for installing Distil Exporter only
+* `distil_collector` - Host group for installing Distil Collector only
 
 If you are making use of the Ansible playbooks bundled within this playbook to manage Distil,
 make sure the target hosts have at least one of the above groups assigned to it.
@@ -48,7 +48,7 @@ make sure the target hosts have at least one of the above groups assigned to it.
 * `distil_lib_dir` - The host directory to use for Distil runtime files. Default is `{{ distil_base_dir }}/lib`.
 * `distil_docker_group` - The group to assign to directories that need to be accessible by users who can use Docker. Default is `root`.
 * `distil_log_dir` - The target directory for Distil service log files on the host. Default is `/var/log/distil`.
-* `distil_log_group` - The group to assign to the logging directory. Default is to assign the Distil service group.
+* `distil_log_dir_group` - The group to assign to the logging directory. Default is to assign the Distil service group.
 * `distil_log_dir_mode` - The permissions for the logging directory. Default is `"0750"`.
 * `distil_ssl_cert` - Service SSL certificate filepath on the host.
 * `distil_ssl_key` - Service SSL private key filepath on the host.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Distil API uses a configurable ERP driver for a number of functions:
 * Fetching a list of products with prices, for generating the current month's quotations
 
 The Ansible collection configures Distil to use the `jsonfile` ERP driver by default.
-This reads a list of products and prices from a `products.json` that is installed
+This reads a list of products and prices from a `products.json` file that is installed
 with the configuration, and allows Distil to work in test environments without a functioning
 Odoo installation.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ make sure the target hosts have at least one of the above groups assigned to it.
 * `distil_log_dir` - The target directory for Distil service log files on the host. Default is `/var/log/distil`.
 * `distil_log_group` - The group to assign to the logging directory. Default is to assign the Distil service group.
 * `distil_log_dir_mode` - The permissions for the logging directory. Default is `"0750"`.
-* `distil_log_file_mode` - The permissions for log files within the logging directory. Default is `"0640"`.
 * `distil_ssl_cert` - Service SSL certificate filepath on the host.
 * `distil_ssl_key` - Service SSL private key filepath on the host.
 * `distil_ssl_cacert` - Service CA certificate bundle filepath on the host.

--- a/README.md
+++ b/README.md
@@ -581,10 +581,11 @@ python -m pip install -r requirements.txt
 
 Once that is done, you should be able to use the `molecule` command to run tests.
 
-There are two test scenarios:
+The following Molecule scenarios can be run:
 
 * `install` - Test the playbooks for the standard deploy of Distil to a region where it is already running.
 * `upgrade` - Test the playbooks for version upgrades (and also deploying Distil to a new region).
+* `ssl_disable` - Test the scenario where public facing Distil services are bound to HTTP ports, rather than HTTPS.
 
 ```bash
 molecule test --scenario-name <scenario-name>

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Related playbooks:
 * `catalystcloud.distil.deploy_manage` - Deploy Distil Manage (to dedicated nodes only)
 * `catalystcloud.distil.deploy_exporter` - Deploy Distil Exporter (to dedicated nodes only)
 * `catalystcloud.distil.deploy_collector` - Deploy Distil Collector (to dedicated nodes only)
+* `catalystcloud.distil.deploy_openstack` - Deploy Distil OpenStack resources (e.g. Keystone)
 
 ### `catalystcloud.distil.upgrade`
 
@@ -239,6 +240,7 @@ Related playbooks (note that these will not remove the base service files, only 
 * `catalystcloud.distil.decommission_manage` - Decommission only Distil Manage
 * `catalystcloud.distil.decommission_exporter` - Decommission only Distil Exporter
 * `catalystcloud.distil.decommission_collector` - Decommission only Distil Collector
+* `catalystcloud.distil.decommission_openstack` - Decommission only Distil OpenStack resources (e.g. Keystone)
 
 ### Other playbooks
 
@@ -254,11 +256,12 @@ Differs from `deploy` and `upgrade` by simply installing/updating the service fi
 
 Related playbooks:
 
-* `catalystcloud.distil.install_base` - Install only Distil base services files
+* `catalystcloud.distil.install_base` - Install only Distil base service files
 * `catalystcloud.distil.install_api` - Install only Distil API
 * `catalystcloud.distil.install_manage` - Install only Distil Manage
 * `catalystcloud.distil.install_exporter` - Install only Distil Exporter
 * `catalystcloud.distil.install_collector` - Install only Distil Collector
+* `catalystcloud.distil.install_openstack` - Install only Distil OpenStack resources (e.g. Keystone)
 
 #### `catalystcloud.distil.uninstall`
 
@@ -268,11 +271,12 @@ Used as the service uninstallation step in the [`catalystcloud.distil.decommissi
 
 Related playbooks:
 
-* `catalystcloud.distil.install_base` - Uninstall only Distil base services files
-* `catalystcloud.distil.install_api` - Uninstall only Distil API
-* `catalystcloud.distil.install_manage` - Uninstall only Distil Manage
-* `catalystcloud.distil.install_exporter` - Uninstall only Distil Exporter
-* `catalystcloud.distil.install_collector` - Uninstall only Distil Collector
+* `catalystcloud.distil.uninstall_base` - Uninstall only Distil base services files
+* `catalystcloud.distil.uninstall_api` - Uninstall only Distil API
+* `catalystcloud.distil.uninstall_manage` - Uninstall only Distil Manage
+* `catalystcloud.distil.uninstall_exporter` - Uninstall only Distil Exporter
+* `catalystcloud.distil.uninstall_collector` - Uninstall only Distil Collector
+* `catalystcloud.distil.uninstall_openstack` - Uninstall only Distil OpenStack resources (e.g. Keystone)
 
 #### `catalystcloud.distil.predeploy`
 
@@ -289,6 +293,7 @@ Related playbooks:
 * `catalystcloud.distil.predeploy_manage` - Run pre-deploy tasks only for Distil Manage
 * `catalystcloud.distil.predeploy_exporter` - Run pre-deploy tasks only for Distil Exporter
 * `catalystcloud.distil.predeploy_collector` - Run pre-deploy tasks only for Distil Collector
+* `catalystcloud.distil.predeploy_openstack` - Run pre-deploy tasks only for Distil OpenStack resources (e.g. Keystone)
 
 #### `catalystcloud.distil.postdeploy`
 
@@ -305,6 +310,7 @@ Related playbooks:
 * `catalystcloud.distil.postdeploy_manage` - Run post-deploy tasks only for Distil Manage
 * `catalystcloud.distil.postdeploy_exporter` - Run post-deploy tasks only for Distil Exporter
 * `catalystcloud.distil.postdeploy_collector` - Run post-deploy tasks only for Distil Collector
+* `catalystcloud.distil.postdeploy_openstack` - Run post-deploy tasks only for Distil OpenStack resources (e.g. Keystone)
 
 ## Roles
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ make sure the target hosts have at least one of the above groups assigned to it.
         * The Keystone project `created_on` field, if it is available. This field is set by Adjutant when it creates new projects on sign-ups. This is usually the newest, and thus the most likely to be used.
         * The oldest found `last_collected` value for the existing projects being serviced by this collector instance. If Keystone is used to create the project directly (and not via Adjutant), this is the one that will likely be used.
         * The maximum `last_collected` value for the current time, which is calculated from `distil_collector_max_collection_start_age`. The default value is 36 days, to allow for at least one month's worth of billing to be caught up if required. This serves as the fallback for when no better alternative is found, as it means the collector will spend some time catching up the project to the present.
+* `distil_collector_exporter_enable` - Enable Distil Collector Exporter, the Prometheus exporter within the Distil Collector service. Default is `true`.
 * `distil_collector_exporter_port` - The default port for Distil Collector Exporter. When using multiple collectors on the same host, define unique ports for each individual collector. Default is `16799`.
 
 #### Distil database configuration

--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ make sure the target hosts have at least one of the above groups assigned to it.
 * `distil_base_dir` - The base directory under which Distil service files will be installed. Default is `/opt/distil`.
 * `distil_config_dir` - The host directory to install Distil configuration files to. Default is `{{ distil_base_dir }}/etc`.
 * `distil_lib_dir` - The host directory to use for Distil runtime files. Default is `{{ distil_base_dir }}/lib`.
-* `distil_log_dir` - The target directory for Distil service log files on the host. Default is `/var/log/distil`.
 * `distil_docker_group` - The group to assign to directories that need to be accessible by users who can use Docker. Default is `root`.
+* `distil_log_dir` - The target directory for Distil service log files on the host. Default is `/var/log/distil`.
 * `distil_log_group` - The group to assign to the logging directory. Default is to assign the Distil service group.
+* `distil_log_dir_mode` - The permissions for the logging directory. Default is `"0750"`.
+* `distil_log_file_mode` - The permissions for log files within the logging directory. Default is `"0640"`.
 * `distil_ssl_cert` - Service SSL certificate filepath on the host.
 * `distil_ssl_key` - Service SSL private key filepath on the host.
 * `distil_ssl_cacert` - Service CA certificate bundle filepath on the host.
-* `distil_openstack_region` - The name of the OpenStack region being deployed to. Distil must be deployed separately to all regions.
+* `distil_openstack_region` - The name of the OpenStack region being deployed to. Distil must be deployed individually to all regions.
 * `distil_user_name` - Distil service user name. Default is `distil`.
 * `distil_user_group` - Distil service group name. Default is `distil`.
 * `distil_user_uid` - UID for the created service user. **Must be unique**. Default is `305`.

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -1,0 +1,16 @@
+objects: {}
+plugins:
+  become: {}
+  cache: {}
+  callback: {}
+  cliconf: {}
+  connection: {}
+  httpapi: {}
+  inventory: {}
+  lookup: {}
+  module: {}
+  netconf: {}
+  shell: {}
+  strategy: {}
+  vars: {}
+version: 1.0.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,8 @@
+ancestor: null
+releases:
+  1.0.0:
+    changes:
+      release_summary: Initial release of the Ansible collection for OpenStack Distil.
+    fragments:
+    - 1.0.0.yaml
+    release_date: '2024-05-23'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,36 @@
+add_plugin_period: true
+changelog_filename_template: ../CHANGELOG.rst
+changelog_filename_version_depth: 0
+changes_file: changelog.yaml
+changes_format: combined
+ignore_other_fragment_extensions: true
+keep_fragments: true
+mention_ancestor: true
+new_plugins_after_name: removed_features
+notesdir: fragments
+output_formats:
+  - md
+  - rst
+prelude_section_name: release_summary
+prelude_section_title: Release Summary
+sanitize_changelog: true
+sections:
+- - major_changes
+  - Major Changes
+- - minor_changes
+  - Minor Changes
+- - breaking_changes
+  - Breaking Changes / Porting Guide
+- - deprecated_features
+  - Deprecated Features
+- - removed_features
+  - Removed Features (previously deprecated)
+- - security_fixes
+  - Security Fixes
+- - bugfixes
+  - Bugfixes
+- - known_issues
+  - Known Issues
+title: Catalystcloud.Distil
+trivial_section_name: trivial
+use_fqcn: true

--- a/changelogs/fragments/1.0.0.yaml
+++ b/changelogs/fragments/1.0.0.yaml
@@ -1,0 +1,3 @@
+---
+
+release_summary: Initial release of the Ansible collection for OpenStack Distil.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,24 @@
+---
+
+namespace: catalystcloud
+name: distil
+version: 1.0.0
+readme: README.md
+authors:
+  - Callum Dickinson <callum.dickinson@catalystcloud.nz>
+
+description: Ansible collection for the OpenStack Distil rating service.
+license:
+  - Apache-2.0
+tags:
+  - cloud
+  - application
+  - linux
+  - openstack
+  - distil
+  - catalystcloud
+dependencies:
+  community.docker: ">=3.8.1"
+  openstack.cloud: ">=1.10.0"
+repository: https://github.com/catalyst-cloud/ansible-collection-distil
+build_ignore: []

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,4 @@
+---
+
+# Matches the oldest supported version of the community.docker collection.
+requires_ansible: ">=2.11.0"

--- a/molecule/base/cleanup.yml
+++ b/molecule/base/cleanup.yml
@@ -2,3 +2,24 @@
 
 - name: Decommission Distil
   ansible.builtin.import_playbook: catalystcloud.distil.decommission
+
+- name: Destroy MariaDB
+  hosts: distil[0]
+  become: true
+  tasks:
+    - name: Destroy MariaDB
+      community.docker.docker_container:
+        name: mariadb
+        state: absent
+
+- name: Cleanup temporary files
+  hosts: distil
+  become: true
+  tasks:
+    - name: Cleanup temporary files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ distil_ssl_cert }}"
+        - "{{ distil_ssl_key }}"

--- a/molecule/base/cleanup.yml
+++ b/molecule/base/cleanup.yml
@@ -16,10 +16,13 @@
   hosts: distil
   become: true
   tasks:
-    - name: Cleanup temporary files
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      loop:
-        - "{{ distil_ssl_cert }}"
-        - "{{ distil_ssl_key }}"
+    - name: Delete SSL keypair (if created)
+      when: distil_ssl_key | default(None)
+      block:
+        - name: Cleanup temporary files
+          ansible.builtin.file:
+            path: "{{ item }}"
+            state: absent
+          loop:
+            - "{{ distil_ssl_cert }}"
+            - "{{ distil_ssl_key }}"

--- a/molecule/base/cleanup.yml
+++ b/molecule/base/cleanup.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Decommission Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.decommission

--- a/molecule/base/converge.yml
+++ b/molecule/base/converge.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Deploy Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.deploy

--- a/molecule/base/decommission.yml
+++ b/molecule/base/decommission.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Decommission Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.decommission

--- a/molecule/base/disable.yml
+++ b/molecule/base/disable.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Disable Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.disable

--- a/molecule/base/enable.yml
+++ b/molecule/base/enable.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Enable Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.enable

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -13,6 +13,6 @@
           - "127.0.0.1:3306:3306"
         env:
           MARIADB_RANDOM_ROOT_PASSWORD: "1"
-          MARIADB_USER: "{{ distil_mariadb_username }}"
-          MARIADB_PASSWORD: "{{ distil_mariadb_password }}"
+          MARIADB_USER: "{{ distil_database_username }}"
+          MARIADB_PASSWORD: "{{ distil_database_password }}"
           MARIADB_DATABASE: "{{ distil_database_name }}"

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -7,11 +7,17 @@
     - name: Create private key (RSA, 4096 bits)
       community.crypto.openssl_privatekey:
         path: "{{ distil_ssl_key }}"
+        owner: root
+        group: distil
+        mode: "0640"
     - name: Create self-signed certificate
       community.crypto.x509_certificate:
         path: "{{ distil_ssl_cert }}"
         privatekey_path: "{{ distil_ssl_key }}"
         provider: selfsigned
+        owner: root
+        group: distil
+        mode: "0640"
 
 - name: Start MariaDB
   hosts: distil[0]

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -8,7 +8,7 @@
       community.crypto.openssl_privatekey:
         path: "{{ distil_ssl_key }}"
         owner: root
-        group: "305"
+        group: "{{ distil_user_gid | string }}"
         mode: "0640"
     - name: Create self-signed certificate
       community.crypto.x509_certificate:
@@ -16,7 +16,7 @@
         privatekey_path: "{{ distil_ssl_key }}"
         provider: selfsigned
         owner: root
-        group: "305"
+        group: "{{ distil_user_gid | string }}"
         mode: "0640"
 
 - name: Start MariaDB

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Create self-signed certificates
+  hosts: distil
+  become: true
+  tasks:
+    - name: Create private key (RSA, 4096 bits)
+      community.crypto.openssl_privatekey:
+        path: "{{ distil_ssl_key }}"
+    - name: Create self-signed certificate
+      community.crypto.x509_certificate:
+        path: "{{ distil_ssl_cert }}"
+        privatekey_path: "{{ distil_ssl_key }}"
+        provider: selfsigned
+
 - name: Start MariaDB
   hosts: distil[0]
   become: true

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Start MariaDB on localhost
-  hosts: localhost
+- name: Start MariaDB
+  hosts: distil[0]
   become: true
   tasks:
     - name: Start MariaDB

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -8,7 +8,7 @@
       community.crypto.openssl_privatekey:
         path: "{{ distil_ssl_key }}"
         owner: root
-        group: distil
+        group: "305"
         mode: "0640"
     - name: Create self-signed certificate
       community.crypto.x509_certificate:
@@ -16,7 +16,7 @@
         privatekey_path: "{{ distil_ssl_key }}"
         provider: selfsigned
         owner: root
-        group: distil
+        group: "305"
         mode: "0640"
 
 - name: Start MariaDB

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -4,20 +4,23 @@
   hosts: distil
   become: true
   tasks:
-    - name: Create private key (RSA, 4096 bits)
-      community.crypto.openssl_privatekey:
-        path: "{{ distil_ssl_key }}"
-        owner: root
-        group: "{{ distil_user_gid | string }}"
-        mode: "0640"
-    - name: Create self-signed certificate
-      community.crypto.x509_certificate:
-        path: "{{ distil_ssl_cert }}"
-        privatekey_path: "{{ distil_ssl_key }}"
-        provider: selfsigned
-        owner: root
-        group: "{{ distil_user_gid | string }}"
-        mode: "0640"
+    - name: Create SSL keypair (if defined)
+      when: distil_ssl_key | default(None)
+      block:
+        - name: Create private key (RSA, 4096 bits)
+          community.crypto.openssl_privatekey:
+            path: "{{ distil_ssl_key }}"
+            owner: root
+            group: "{{ distil_user_gid | string }}"
+            mode: "0640"
+        - name: Create self-signed certificate
+          community.crypto.x509_certificate:
+            path: "{{ distil_ssl_cert }}"
+            privatekey_path: "{{ distil_ssl_key }}"
+            provider: selfsigned
+            owner: root
+            group: "{{ distil_user_gid | string }}"
+            mode: "0640"
 
 - name: Start MariaDB
   hosts: distil[0]

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Start MariaDB on localhost
+  hosts: localhost
+  become: true
+  tasks:
+    - name: Start MariaDB
+      community.docker.docker_container:
+        name: mariadb
+        image: mariadb:11.3.2
+        state: started
+        ports:
+          - "127.0.0.1:3306:3306"
+        env:
+          MARIADB_RANDOM_ROOT_PASSWORD: "1"
+          MARIADB_USER: "{{ distil_mariadb_username }}"
+          MARIADB_PASSWORD: "{{ distil_mariadb_password }}"
+          MARIADB_DATABASE: "{{ distil_database_name }}"

--- a/molecule/base/prepare.yml
+++ b/molecule/base/prepare.yml
@@ -16,3 +16,8 @@
           MARIADB_USER: "{{ distil_database_username }}"
           MARIADB_PASSWORD: "{{ distil_database_password }}"
           MARIADB_DATABASE: "{{ distil_database_name }}"
+    - name: Wait until MariaDB is online
+      ansible.builtin.wait_for:
+        host: "127.0.0.1"
+        port: 3306
+        timeout: 300

--- a/molecule/base/side_effect.yml
+++ b/molecule/base/side_effect.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Upgrade Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.upgrade

--- a/molecule/base/stop.yml
+++ b/molecule/base/stop.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Stop Distil
+  ansible.builtin.import_playbook: catalystcloud.distil.stop

--- a/molecule/base/verify.yml
+++ b/molecule/base/verify.yml
@@ -1,0 +1,220 @@
+---
+
+- name: Verify Distil Base
+  hosts: distil
+  become: true
+  tasks:
+    - name: Get user metadata
+      ansible.builtin.getent:
+        database: passwd
+        key: distil
+    - name: Check that the Distil service user has the correct UID
+      ansible.builtin.assert:
+        that:
+          - (getent_passwd['distil'][1] | int) == 305
+        fail_msg: "Distil service user has the incorrect UID {{ getent_passwd['distil'][1] }}"
+        quiet: true
+    - name: Check that the Distil service user has the correct GID
+      ansible.builtin.assert:
+        that:
+          - (getent_passwd['distil'][2] | int) == 305
+        fail_msg: "Distil service user has the incorrect GID {{ getent_passwd['distil'][2] }}"
+        quiet: true
+    - name: Check that the Distil service user has the correct home directory
+      ansible.builtin.assert:
+        that:
+          - getent_passwd['distil'][4] == '/opt/distil/lib'
+        fail_msg: "Distil service user has the incorrect home directory {{ getent_passwd['distil'][4] }}"
+        quiet: true
+    - name: Check Distil service user additional groups (if defined)
+      when: distil_user_groups | default([])
+      block:
+        - name: Get group metadata
+          ansible.builtin.getent:
+            database: group
+        - name: Check that the Distil service user was added to all additional groups
+          ansible.builtin.assert:
+            that:
+              - "'distil' in getent_group[item][2].split(',')"
+            fail_msg: "Distil service user was not added to the group '{{ item }}'"
+            quiet: true
+          loop: "{{ distil_user_groups }}"
+    - name: Check that the base configuration file exists
+      ansible.builtin.stat:
+        path: /opt/distil/etc/distil.conf
+      register: config_file
+      failed_when: not (config_file.stat.exists | default(False))
+    - name: Check that the meter mappings file exists
+      ansible.builtin.stat:
+        path: /opt/distil/etc/meter_mappings.yml
+      register: metermappings_file
+      failed_when: not (metermappings_file.stat.exists | default(False))
+    - name: Check that the transformer file exists
+      ansible.builtin.stat:
+        path: /opt/distil/etc/transformer.yml
+      register: transformer_file
+      failed_when: not (transformer_file.stat.exists | default(False))
+    - name: Check that the JSON file ERP driver products file exists
+      ansible.builtin.stat:
+        path: /opt/distil/etc/products.json
+      register: products_file
+      failed_when: not (products_file.stat.exists | default(False))
+    - name: Check that the Keystone policy file exists
+      ansible.builtin.stat:
+        path: /opt/distil/etc/policy.json
+      register: policy_file
+      failed_when: not (policy_file.stat.exists | default(False))
+    - name: Check that the runtime volume directory (service home directory) exists
+      ansible.builtin.stat:
+        path: /opt/distil/lib
+      register: runtime_dir
+      failed_when: not (runtime_dir.stat.exists | default(False))
+    - name: Check that the logging directory exists
+      ansible.builtin.stat:
+        path: /var/log/distil
+      register: log_dir
+      failed_when: not (log_dir.stat.exists | default(False))
+    - name: Check that the logrotate config file exists
+      ansible.builtin.stat:
+        path: /etc/logrotate.d/distil-logs
+      register: logrotate_file
+      failed_when: not (logrotate_file.stat.exists | default(False))
+
+- name: Verify Distil Manage
+  hosts: distil
+  become: true
+  tasks:
+    - name: Check that the service README file exists
+      ansible.builtin.stat:
+        path: /opt/distil/manage/README.md
+      register: readme_file
+      failed_when: not (readme_file.stat.exists | default(False))
+    - name: Check that the service compose file exists
+      ansible.builtin.stat:
+        path: /opt/distil/manage/docker-compose.yml
+      register: dockercompose_file
+      failed_when: not (dockercompose_file.stat.exists | default(False))
+
+- name: Verify Distil API
+  hosts: distil
+  become: true
+  tasks:
+    - name: Check that the WSGI script file exists
+      ansible.builtin.stat:
+        path: /opt/distil/api/distil-api.wsgi
+      register: wsgi_file
+      failed_when: not (wsgi_file.stat.exists | default(False))
+    - name: Check that the service README file exists
+      ansible.builtin.stat:
+        path: /opt/distil/api/README.md
+      register: readme_file
+      failed_when: not (readme_file.stat.exists | default(False))
+    - name: Check that the service compose file exists
+      ansible.builtin.stat:
+        path: /opt/distil/api/docker-compose.yml
+      register: dockercompose_file
+      failed_when: not (dockercompose_file.stat.exists | default(False))
+    - name: Get running services
+      ansible.builtin.command:
+        cmd: docker-compose --file docker-compose.yml ps --services
+        chdir: /opt/distil/api
+      register: dockercompose_services
+      changed_when: false
+    - name: Check that the service is running
+      ansible.builtin.assert:
+        that:
+          - "'distil-api' in dockercompose_services.stdout_lines"
+        fail_msg: "Service is not running"
+        quiet: true
+    - name: Check that Distil API is online
+      ansible.builtin.wait_for:
+        host: "{{ ansible_default_ipv4.address }}"
+        port: 9999
+        timeout: 30
+
+- name: Verify Distil Exporter
+  hosts: distil
+  become: true
+  tasks:
+    - name: Check that the WSGI script file exists
+      ansible.builtin.stat:
+        path: /opt/distil/exporter/distil-exporter
+      register: wsgi_file
+      failed_when: not (wsgi_file.stat.exists | default(False))
+    - name: Check that the service README file exists
+      ansible.builtin.stat:
+        path: /opt/distil/exporter/README.md
+      register: readme_file
+      failed_when: not (readme_file.stat.exists | default(False))
+    - name: Check that the service compose file exists
+      ansible.builtin.stat:
+        path: /opt/distil/exporter/docker-compose.yml
+      register: dockercompose_file
+      failed_when: not (dockercompose_file.stat.exists | default(False))
+    - name: Get running services
+      ansible.builtin.command:
+        cmd: docker-compose --file docker-compose.yml ps --services
+        chdir: /opt/distil/exporter
+      register: dockercompose_services
+      changed_when: false
+    - name: Check that the service is running
+      ansible.builtin.assert:
+        that:
+          - "'distil-exporter' in dockercompose_services.stdout_lines"
+        fail_msg: "Service is not running"
+        quiet: true
+    - name: Check that Distil Exporter is online
+      ansible.builtin.wait_for:
+        host: "{{ ansible_default_ipv4.address }}"
+        port: 16798
+        timeout: 30
+
+- name: Verify Distil Collector
+  hosts: distil
+  become: true
+  tasks:
+    - name: Check that the service README file exists
+      ansible.builtin.stat:
+        path: "/opt/distil/collector{{ item }}/README.md"
+      register: readme_file
+      failed_when: not (readme_file.stat.exists | default(False))
+      loop:
+        - ""
+    - name: Check that the service compose files exist
+      ansible.builtin.stat:
+        path: "/opt/distil/collector{{ item }}/docker-compose.yml"
+      register: dockercompose_file
+      failed_when: not (dockercompose_file.stat.exists | default(False))
+      loop:
+        - ""
+    - name: Check that the collector configuration files exist
+      ansible.builtin.stat:
+        path: "/opt/distil/collector{{ item }}/distil.conf"
+      register: config_file
+      failed_when: not (config_file.stat.exists | default(False))
+      loop:
+        - ""
+    - name: Get running services
+      ansible.builtin.command:
+        cmd: docker-compose --file docker-compose.yml ps --services
+        chdir: "/opt/distil/collector{{ item }}"
+      register: dockercompose_services
+      changed_when: false
+      loop:
+        - ""
+    - name: Check that the services are running
+      ansible.builtin.assert:
+        that:
+          - ('distil-collector' + item.item) in item.stdout_lines
+        fail_msg: "Service is not running"
+        quiet: true
+      loop: "{{ dockercompose_services.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+    - name: Check that the Distil Collector Exporters are online
+      ansible.builtin.wait_for:
+        host: "{{ ansible_default_ipv4.address }}"
+        port: "{{ item }}"
+        timeout: 30
+      loop:
+        - 16799

--- a/molecule/base/verify.yml
+++ b/molecule/base/verify.yml
@@ -61,7 +61,7 @@
       failed_when: not (products_file.stat.exists | default(False))
     - name: Check that the Keystone policy file exists
       ansible.builtin.stat:
-        path: /opt/distil/etc/policy.json
+        path: /opt/distil/etc/policy.yaml
       register: policy_file
       failed_when: not (policy_file.stat.exists | default(False))
     - name: Check that the runtime volume directory (service home directory) exists

--- a/molecule/base/verify.yml
+++ b/molecule/base/verify.yml
@@ -137,7 +137,7 @@
   tasks:
     - name: Check that the WSGI script file exists
       ansible.builtin.stat:
-        path: /opt/distil/exporter/distil-exporter
+        path: /opt/distil/exporter/distil-exporter.wsgi
       register: wsgi_file
       failed_when: not (wsgi_file.stat.exists | default(False))
     - name: Check that the service README file exists

--- a/molecule/base/verify_decommission.yml
+++ b/molecule/base/verify_decommission.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Verify Distil decommission on all hosts
+  hosts: distil
+  become: true
+  tasks:
+    - name: Check that all Distil containers have been destroyed
+      ansible.builtin.command:
+        cmd: docker ps --all
+      register: existing_containers
+      changed_when: false
+      failed_when: "'distil' in existing_containers.stdout"
+    - name: Check that all Distil container images have been removed
+      ansible.builtin.command:
+        cmd: docker image ls
+      register: container_images
+      changed_when: false
+      failed_when: "'ghcr.io/catalyst-cloud/distil-docker' in container_images.stdout"
+    - name: Check that the base directory does not exist
+      ansible.builtin.stat:
+        path: /opt/distil
+      register: base_dir
+      failed_when: base_dir.stat.exists | default(False)
+    - name: Check that the logging directory does not exist
+      ansible.builtin.stat:
+        path: /var/log/distil
+      register: log_dir
+      failed_when: log_dir.stat.exists | default(False)
+    - name: Check that the logrotate config file does not exist
+      ansible.builtin.stat:
+        path: /etc/logrotate.d/distil-logs
+      register: logrotate_file
+      failed_when: logrotate_file.stat.exists | default(False)
+    - name: Get user metadata
+      ansible.builtin.getent:
+        database: passwd
+    - name: Get group metadata
+      ansible.builtin.getent:
+        database: group
+    - name: Check that the Distil service user does not exist
+      ansible.builtin.assert:
+        that:
+          - "'distil' not in getent_passwd"
+        fail_msg: "Distil service user not deleted"
+        quiet: true
+    - name: Check that the Distil service group does not exist
+      ansible.builtin.assert:
+        that:
+          - "'distil' not in getent_group"
+        fail_msg: "Distil service group not deleted"
+        quiet: true

--- a/molecule/base/verify_disable.yml
+++ b/molecule/base/verify_disable.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Verify Distil disable on all hosts
+  hosts: distil
+  become: true
+  tasks:
+    - name: Check that all Distil containers have been destroyed
+      ansible.builtin.command:
+        cmd: docker ps --all
+      register: existing_containers
+      changed_when: false
+      failed_when: "'distil' in existing_containers.stdout"

--- a/molecule/base/verify_stop.yml
+++ b/molecule/base/verify_stop.yml
@@ -132,7 +132,7 @@
   tasks:
     - name: Check that the WSGI script file exists
       ansible.builtin.stat:
-        path: /opt/distil/exporter/distil-exporter
+        path: /opt/distil/exporter/distil-exporter.wsgi
       register: wsgi_file
       failed_when: not (wsgi_file.stat.exists | default(False))
     - name: Check that the service README file exists

--- a/molecule/base/verify_stop.yml
+++ b/molecule/base/verify_stop.yml
@@ -118,18 +118,13 @@
       community.docker.docker_container_info:
         name: distil-api
       register: result
-    - name: Check that the service container is running
+    - name: Check that the service container is not running
       ansible.builtin.assert:
         that:
-          - result.container.State.Running
-        success_msg: Container is running
-        fail_msg: Container is not running
+          - not result.container.State.Running
+        success_msg: Container is not running
+        fail_msg: Container is running
         quiet: true
-    - name: Check that Distil API is online
-      ansible.builtin.wait_for:
-        host: "{{ ansible_default_ipv4.address }}"
-        port: 9999
-        timeout: 30
 
 - name: Verify Distil Exporter
   hosts: distil
@@ -154,18 +149,13 @@
       community.docker.docker_container_info:
         name: distil-exporter
       register: result
-    - name: Check that the service container is running
+    - name: Check that the service container is not running
       ansible.builtin.assert:
         that:
-          - result.container.State.Running
-        success_msg: Container is running
-        fail_msg: Container is not running
+          - not result.container.State.Running
+        success_msg: Container is not running
+        fail_msg: Container is running
         quiet: true
-    - name: Check that Distil Exporter is online
-      ansible.builtin.wait_for:
-        host: "{{ ansible_default_ipv4.address }}"
-        port: 16798
-        timeout: 30
 
 - name: Verify Distil Collector
   hosts: distil
@@ -198,20 +188,13 @@
       register: result
       loop:
         - ""
-    - name: Check that the service container is running
+    - name: Check that the service container is not running
       ansible.builtin.assert:
         that:
-          - item.container.State.Running
-        success_msg: Container is running
-        fail_msg: Container is not running
+          - not item.container.State.Running
+        success_msg: Container is not running
+        fail_msg: Container is running
         quiet: true
       loop: "{{ result.results }}"
       loop_control:
         label: "{{ item.item }}"
-    - name: Check that the Distil Collector Exporters are online
-      ansible.builtin.wait_for:
-        host: "{{ ansible_default_ipv4.address }}"
-        port: "{{ item }}"
-        timeout: 30
-      loop:
-        - 16799

--- a/molecule/base/verify_stop.yml
+++ b/molecule/base/verify_stop.yml
@@ -61,7 +61,7 @@
       failed_when: not (products_file.stat.exists | default(False))
     - name: Check that the Keystone policy file exists
       ansible.builtin.stat:
-        path: /opt/distil/etc/policy.json
+        path: /opt/distil/etc/policy.yaml
       register: policy_file
       failed_when: not (policy_file.stat.exists | default(False))
     - name: Check that the runtime volume directory (service home directory) exists

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -25,6 +25,12 @@ provisioner:
     verify: ../base/verify.yml
     side_effect: ../base/converge.yml
     cleanup: ../base/cleanup.yml
+  # config_options:
+  #   defaults:
+  #     timeout: 30   # Uncomment to crease SSH and privilege escalation timeout.
+  #     verbosity: 3  # Uncomment to increase Ansible verbosity. Default is 0.
+  #   diff:
+  #     always: true  # Uncomment to show task diffs.
   inventory:
     group_vars:
       distil:

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -28,6 +28,7 @@ provisioner:
   inventory:
     group_vars:
       distil:
+        distil_user_gid: 305
         distil_ssl_cert: "/tmp/molecule-distil.crt"
         distil_ssl_key: "/tmp/molecule-distil.key"
         distil_database_hosts:

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -28,6 +28,8 @@ provisioner:
   inventory:
     group_vars:
       distil:
+        distil_ssl_cert: "/tmp/molecule-distil.pem"
+        distil_ssl_key: "/tmp/molecule-distil.key"
         distil_database_hosts:
           - "localhost:3306"
         distil_database_username: "distil"

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -28,7 +28,7 @@ provisioner:
   inventory:
     group_vars:
       distil:
-        distil_ssl_cert: "/tmp/molecule-distil.pem"
+        distil_ssl_cert: "/tmp/molecule-distil.crt"
         distil_ssl_key: "/tmp/molecule-distil.key"
         distil_database_hosts:
           - "localhost:3306"

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -68,9 +68,9 @@ scenario:
     - verify ../base/verify_disable.yml
     - side_effect ../base/enable.yml
     - verify
-    - side_effect ../base/uninstall.yml
-    - verify ../base/verify_uninstall.yml
-    # Run uninstall again to ensure it works even if already uninstalled.
-    - side_effect ../base/uninstall.yml
+    - side_effect ../base/decommission.yml
+    - verify ../base/verify_decommission.yml
+    # Run decommission again to ensure it works even if already uninstalled.
+    - side_effect ../base/decommission.yml
     - cleanup
     - destroy

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -70,7 +70,5 @@ scenario:
     - verify
     - side_effect ../base/decommission.yml
     - verify ../base/verify_decommission.yml
-    # Run decommission again to ensure it works even if already uninstalled.
-    - side_effect ../base/decommission.yml
     - cleanup
     - destroy

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -1,0 +1,65 @@
+---
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+
+driver:
+  name: default
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+
+platforms:
+  - name: localhost
+    groups:
+      - distil
+
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    converge: ../base/converge.yml
+    verify: ../base/verify.yml
+    side_effect: ../base/converge.yml
+    cleanup: ../base/cleanup.yml
+  inventory:
+    group_vars:
+      distil:
+        distil_database_hosts:
+          - "localhost:3306"
+        distil_database_username: "distil"
+        distil_database_password: "123456"
+        distil_database_name: "distil"
+        # NOTE(callumdickinson): Do not run Distil Keystone resource management
+        # in Molecule, as Keystone is not installed in the environment.
+        distil_keystone_enable: false
+
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - syntax
+    - prepare
+    - check
+    - converge
+    - idempotence
+    - verify
+    - side_effect ../base/stop.yml
+    - verify ../base/verify_stop.yml
+    - side_effect ../base/enable.yml
+    - verify
+    - side_effect ../base/disable.yml
+    - verify ../base/verify_disable.yml
+    - side_effect ../base/enable.yml
+    - verify
+    - side_effect ../base/uninstall.yml
+    - verify ../base/verify_uninstall.yml
+    # Run uninstall again to ensure it works even if already uninstalled.
+    - side_effect ../base/uninstall.yml
+    - cleanup

--- a/molecule/install/molecule.yml
+++ b/molecule/install/molecule.yml
@@ -45,6 +45,7 @@ scenario:
     - dependency
     - cleanup
     - syntax
+    - create
     - prepare
     - check
     - converge
@@ -63,3 +64,4 @@ scenario:
     # Run uninstall again to ensure it works even if already uninstalled.
     - side_effect ../base/uninstall.yml
     - cleanup
+    - destroy

--- a/molecule/install/prepare.yml
+++ b/molecule/install/prepare.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Prepare Base
+  ansible.builtin.import_playbook: ../base/prepare.yml
+
+- name: Initialise Distil database
+  hosts: distil[0]
+  become: true
+  serial: 1
+  tasks:
+    - name: Install Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: install
+    - name: Install Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: install
+    - name: Migrate Distil
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: migrate
+    - name: Uninstall Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: uninstall
+    - name: Uninstall Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: uninstall

--- a/molecule/ssl_disable/molecule.yml
+++ b/molecule/ssl_disable/molecule.yml
@@ -59,7 +59,5 @@ scenario:
     - converge
     - idempotence
     - verify
-    - side_effect ../base/decommission.yml
-    - verify ../base/verify_decommission.yml
     - cleanup
     - destroy

--- a/molecule/ssl_disable/molecule.yml
+++ b/molecule/ssl_disable/molecule.yml
@@ -20,10 +20,10 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
-    prepare: ../base/prepare.yml
-    converge: ../base/side_effect.yml
+    prepare: ../install/prepare.yml
+    converge: ../base/converge.yml
     verify: ../base/verify.yml
-    side_effect: ../base/side_effect.yml
+    side_effect: ../base/converge.yml
     cleanup: ../base/cleanup.yml
   # config_options:
   #   defaults:
@@ -35,7 +35,7 @@ provisioner:
     group_vars:
       distil:
         distil_user_gid: 305
-        distil_ssl_disable: false
+        distil_ssl_enable: false
         distil_database_hosts:
           - "localhost:3306"
         distil_database_username: "distil"
@@ -56,19 +56,10 @@ scenario:
     - create
     - prepare
     - check
-    - side_effect
-    - verify
-    - side_effect ../base/stop.yml
-    - verify ../base/verify_stop.yml
-    - side_effect ../base/enable.yml
-    - verify
-    - side_effect ../base/disable.yml
-    - verify ../base/verify_disable.yml
-    - side_effect ../base/enable.yml
+    - converge
+    - idempotence
     - verify
     - side_effect ../base/decommission.yml
     - verify ../base/verify_decommission.yml
-    # Run decommission again to ensure it works even if already uninstalled.
-    - side_effect ../base/decommission.yml
     - cleanup
     - destroy

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -28,6 +28,7 @@ provisioner:
   inventory:
     group_vars:
       distil:
+        distil_user_gid: 305
         distil_ssl_cert: "/tmp/molecule-distil.crt"
         distil_ssl_key: "/tmp/molecule-distil.key"
         distil_database_hosts:

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -69,7 +69,5 @@ scenario:
     - verify
     - side_effect ../base/decommission.yml
     - verify ../base/verify_decommission.yml
-    # Run decommission again to ensure it works even if already uninstalled.
-    - side_effect ../base/decommission.yml
     - cleanup
     - destroy

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -1,0 +1,64 @@
+---
+
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+
+driver:
+  name: default
+  options:
+    managed: false
+    ansible_connection_options:
+      ansible_connection: local
+
+platforms:
+  - name: localhost
+    groups:
+      - distil
+
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../base/prepare.yml
+    converge: ../base/side_effect.yml
+    verify: ../base/verify.yml
+    side_effect: ../base/side_effect.yml
+    cleanup: ../base/cleanup.yml
+  inventory:
+    group_vars:
+      distil:
+        distil_database_hosts:
+          - "localhost:3306"
+        distil_database_username: "distil"
+        distil_database_password: "123456"
+        distil_database_name: "distil"
+        # NOTE(callumdickinson): Do not run Distil Keystone resource management
+        # in Molecule, as Keystone is not installed in the environment.
+        distil_keystone_enable: false
+
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - syntax
+    - prepare
+    - check
+    - side_effect
+    - verify
+    - side_effect ../base/stop.yml
+    - verify ../base/verify_stop.yml
+    - side_effect ../base/enable.yml
+    - verify
+    - side_effect ../base/disable.yml
+    - verify ../base/verify_disable.yml
+    - side_effect ../base/enable.yml
+    - verify
+    - side_effect ../base/uninstall.yml
+    - verify ../base/verify_uninstall.yml
+    # Run uninstall again to ensure it works even if already uninstalled.
+    - side_effect ../base/uninstall.yml
+    - cleanup

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -28,6 +28,8 @@ provisioner:
   inventory:
     group_vars:
       distil:
+        distil_ssl_cert: "/tmp/molecule-distil.pem"
+        distil_ssl_key: "/tmp/molecule-distil.key"
         distil_database_hosts:
           - "localhost:3306"
         distil_database_username: "distil"

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -45,6 +45,7 @@ scenario:
     - dependency
     - cleanup
     - syntax
+    - create
     - prepare
     - check
     - side_effect
@@ -62,3 +63,4 @@ scenario:
     # Run uninstall again to ensure it works even if already uninstalled.
     - side_effect ../base/uninstall.yml
     - cleanup
+    - destroy

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -25,6 +25,12 @@ provisioner:
     verify: ../base/verify.yml
     side_effect: ../base/side_effect.yml
     cleanup: ../base/cleanup.yml
+  # config_options:
+  #   defaults:
+  #     timeout: 30   # Uncomment to crease SSH and privilege escalation timeout.
+  #     verbosity: 3  # Uncomment to increase Ansible verbosity. Default is 0.
+  #   diff:
+  #     always: true  # Uncomment to show task diffs.
   inventory:
     group_vars:
       distil:

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -28,7 +28,7 @@ provisioner:
   inventory:
     group_vars:
       distil:
-        distil_ssl_cert: "/tmp/molecule-distil.pem"
+        distil_ssl_cert: "/tmp/molecule-distil.crt"
         distil_ssl_key: "/tmp/molecule-distil.key"
         distil_database_hosts:
           - "localhost:3306"

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -67,9 +67,9 @@ scenario:
     - verify ../base/verify_disable.yml
     - side_effect ../base/enable.yml
     - verify
-    - side_effect ../base/uninstall.yml
-    - verify ../base/verify_uninstall.yml
-    # Run uninstall again to ensure it works even if already uninstalled.
-    - side_effect ../base/uninstall.yml
+    - side_effect ../base/decommission.yml
+    - verify ../base/verify_decommission.yml
+    # Run decommission again to ensure it works even if already uninstalled.
+    - side_effect ../base/decommission.yml
     - cleanup
     - destroy

--- a/molecule/upgrade/molecule.yml
+++ b/molecule/upgrade/molecule.yml
@@ -35,7 +35,8 @@ provisioner:
     group_vars:
       distil:
         distil_user_gid: 305
-        distil_ssl_disable: false
+        distil_ssl_cert: "/tmp/molecule-distil.crt"
+        distil_ssl_key: "/tmp/molecule-distil.key"
         distil_database_hosts:
           - "localhost:3306"
         distil_database_username: "distil"

--- a/playbooks/decommission.yml
+++ b/playbooks/decommission.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Disable Distil
+  ansible.builtin.import_playbook: disable.yml
+
+- name: Uninstall Distil
+  ansible.builtin.import_playbook: uninstall.yml

--- a/playbooks/decommission_api.yml
+++ b/playbooks/decommission_api.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Disable Distil API (dedicated hosts)
+  ansible.builtin.import_playbook: disable_api.yml
+
+- name: Uninstall Distil API (dedicated hosts)
+  ansible.builtin.import_playbook: uninstall_api.yml

--- a/playbooks/decommission_collector.yml
+++ b/playbooks/decommission_collector.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Disable Distil Collector (dedicated hosts)
+  ansible.builtin.import_playbook: disable_collector.yml
+
+- name: Uninstall Distil Collector (dedicated hosts)
+  ansible.builtin.import_playbook: uninstall_collector.yml

--- a/playbooks/decommission_exporter.yml
+++ b/playbooks/decommission_exporter.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Disable Distil Exporter (dedicated hosts)
+  ansible.builtin.import_playbook: disable_exporter.yml
+
+- name: Uninstall Distil Exporter (dedicated hosts)
+  ansible.builtin.import_playbook: uninstall_exporter.yml

--- a/playbooks/decommission_manage.yml
+++ b/playbooks/decommission_manage.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Uninstall Distil Manage (dedicated hosts)
+  ansible.builtin.import_playbook: uninstall_manage.yml

--- a/playbooks/decommission_openstack.yml
+++ b/playbooks/decommission_openstack.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Uninstall Distil OpenStack resources
+  ansible.builtin.import_playbook: uninstall_openstack.yml

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Deploy Distil OpenStack resources
+  ansible.builtin.import_playbook: deploy_openstack.yml
+
+- name: Deploy Distil (nodes running all services)
+  ansible.builtin.import_playbook: deploy_distil.yml
+
+- name: Deploy Distil Manage (dedicated nodes)
+  ansible.builtin.import_playbook: deploy_manage.yml
+
+- name: Deploy Distil API (dedicated nodes)
+  ansible.builtin.import_playbook: deploy_api.yml
+
+- name: Deploy Distil Exporter (dedicated nodes)
+  ansible.builtin.import_playbook: deploy_exporter.yml
+
+- name: Deploy Distil Collector (dedicated nodes)
+  ansible.builtin.import_playbook: deploy_collector.yml

--- a/playbooks/deploy_api.yml
+++ b/playbooks/deploy_api.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Deploy Distil API (dedicated nodes)
+  hosts: distil_api:!distil
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: predeploy
+    - name: Deploy Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+    - name: Deploy Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+    - name: Run post-deploy tasks for Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: postdeploy

--- a/playbooks/deploy_collector.yml
+++ b/playbooks/deploy_collector.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Deploy Distil Collector (dedicated nodes)
+  hosts: distil_collector:!distil
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: predeploy
+    - name: Deploy Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+    - name: Deploy Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+    - name: Run post-deploy tasks for Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: postdeploy

--- a/playbooks/deploy_distil.yml
+++ b/playbooks/deploy_distil.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Deploy Distil (nodes running all services)
+  hosts: distil
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: predeploy
+    - name: Deploy Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+    - name: Deploy Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+    - name: Deploy Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+    - name: Deploy Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+    - name: Run post-deploy tasks for Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: postdeploy

--- a/playbooks/deploy_distil.yml
+++ b/playbooks/deploy_distil.yml
@@ -17,6 +17,10 @@
       ansible.builtin.include_role:
         name: catalystcloud.distil.api
         tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: predeploy
     - name: Run pre-deploy tasks for Distil Base
       ansible.builtin.include_role:
         name: catalystcloud.distil.base
@@ -24,6 +28,9 @@
     - name: Deploy Distil Base
       ansible.builtin.include_role:
         name: catalystcloud.distil.base
+    - name: Deploy Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
     - name: Deploy Distil API
       ansible.builtin.include_role:
         name: catalystcloud.distil.api
@@ -44,6 +51,10 @@
     - name: Run post-deploy tasks for Distil API
       ansible.builtin.include_role:
         name: catalystcloud.distil.api
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
         tasks_from: postdeploy
     - name: Run post-deploy tasks for Distil Base
       ansible.builtin.include_role:

--- a/playbooks/deploy_exporter.yml
+++ b/playbooks/deploy_exporter.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Deploy Distil Exporter (dedicated nodes)
+  hosts: distil_exporter:!distil
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: predeploy
+    - name: Deploy Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+    - name: Deploy Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+    - name: Run post-deploy tasks for Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: postdeploy

--- a/playbooks/deploy_manage.yml
+++ b/playbooks/deploy_manage.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Deploy Distil Manage (dedicated nodes)
+  hosts: distil_manage:!distil
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: predeploy
+    - name: Run pre-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: predeploy
+    - name: Deploy Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+    - name: Deploy Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+    - name: Run post-deploy tasks for Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: postdeploy
+    - name: Run post-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: postdeploy

--- a/playbooks/deploy_openstack.yml
+++ b/playbooks/deploy_openstack.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Deploy Distil OpenStack resources
+  hosts: localhost
+  gather_facts: false
+  become: false  # Don't escalate on localhost.
+  tasks:
+    - name: Manage Distil Keystone resources (if enabled)
+      when: distil_keystone_enable | default(True)
+      block:
+        - name: Run pre-deploy tasks for Distil Keystone resources
+          ansible.builtin.include_role:
+            name: catalystcloud.distil.keystone
+            tasks_from: predeploy
+        - name: Deploy Distil Keystone resources
+          ansible.builtin.include_role:
+            name: catalystcloud.distil.keystone
+        - name: Run post-deploy tasks for Distil Keystone resources
+          ansible.builtin.include_role:
+            name: catalystcloud.distil.keystone
+            tasks_from: postdeploy

--- a/playbooks/disable.yml
+++ b/playbooks/disable.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Disable Distil Collector
+  ansible.builtin.import_playbook: disable_collector.yml
+
+- name: Disable Distil Exporter
+  ansible.builtin.import_playbook: disable_exporter.yml
+
+- name: Disable Distil API
+  ansible.builtin.import_playbook: disable_api.yml

--- a/playbooks/disable_api.yml
+++ b/playbooks/disable_api.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Disable Distil API
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Disable Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: disable

--- a/playbooks/disable_collector.yml
+++ b/playbooks/disable_collector.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Disable Distil Collector
+  hosts: distil:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Disable Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: disable

--- a/playbooks/disable_exporter.yml
+++ b/playbooks/disable_exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Disable Distil Exporter
+  hosts: distil:distil_exporter
+  become: true
+  serial: 1
+  tasks:
+    - name: Disable Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: disable

--- a/playbooks/enable.yml
+++ b/playbooks/enable.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Enable Distil API
+  ansible.builtin.import_playbook: enable_api.yml
+
+- name: Enable Distil Exporter
+  ansible.builtin.import_playbook: enable_exporter.yml
+
+- name: Enable Distil Collector
+  ansible.builtin.import_playbook: enable_collector.yml

--- a/playbooks/enable_api.yml
+++ b/playbooks/enable_api.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Enable Distil API
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Enable Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: enable

--- a/playbooks/enable_collector.yml
+++ b/playbooks/enable_collector.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Enable Distil Collector
+  hosts: distil:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Enable Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: enable

--- a/playbooks/enable_exporter.yml
+++ b/playbooks/enable_exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Enable Distil Exporter
+  hosts: distil:distil_exporter
+  become: true
+  serial: 1
+  tasks:
+    - name: Enable Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: enable

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Install Distil OpenStack resources
+  ansible.builtin.import_playbook: install_openstack.yml
+
+- name: Install Distil Base
+  ansible.builtin.import_playbook: install_base.yml
+
+- name: Install Distil Manage
+  ansible.builtin.import_playbook: install_manage.yml
+
+- name: Install Distil API
+  ansible.builtin.import_playbook: install_api.yml
+
+- name: Install Distil Exporter
+  ansible.builtin.import_playbook: install_exporter.yml
+
+- name: Install Distil Collector
+  ansible.builtin.import_playbook: install_collector.yml

--- a/playbooks/install_api.yml
+++ b/playbooks/install_api.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install Distil Exporter
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Install Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: install

--- a/playbooks/install_base.yml
+++ b/playbooks/install_base.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install Distil Base
+  hosts: distil:distil_api:distil_manage:distil_exporter:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Install Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: install

--- a/playbooks/install_collector.yml
+++ b/playbooks/install_collector.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install Distil Collector
+  hosts: distil:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Install Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: install

--- a/playbooks/install_exporter.yml
+++ b/playbooks/install_exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install Distil Exporter
+  hosts: distil:distil_exporter
+  become: true
+  serial: 1
+  tasks:
+    - name: Install Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: install

--- a/playbooks/install_manage.yml
+++ b/playbooks/install_manage.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install Distil Manage
+  hosts: distil:distil_manage
+  become: true
+  serial: 1
+  tasks:
+    - name: Install Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: install

--- a/playbooks/install_openstack.yml
+++ b/playbooks/install_openstack.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install Distil OpenStack resources
+  hosts: localhost
+  gather_facts: false
+  become: false  # Don't escalate on localhost.
+  tasks:
+    - name: Install Distil Keystone resources
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.keystone
+      when: distil_keystone_enable | default(True)

--- a/playbooks/migrate.yml
+++ b/playbooks/migrate.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Migrate Distil
+  hosts: distil:distil_manage[0]
+  become: true
+  serial: 1
+  tasks:
+    - name: Migrate Distil
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: migrate

--- a/playbooks/postdeploy.yml
+++ b/playbooks/postdeploy.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Run post-deploy tasks for Distil Collector
+  ansible.builtin.import_playbook: postdeploy_collector.yml
+
+- name: Run post-deploy tasks for Distil Exporter
+  ansible.builtin.import_playbook: postdeploy_exporter.yml
+
+- name: Run post-deploy tasks for Distil API
+  ansible.builtin.import_playbook: postdeploy_api.yml
+
+- name: Run post-deploy tasks for Distil Manage
+  ansible.builtin.import_playbook: postdeploy_manage.yml
+
+- name: Run post-deploy tasks for Distil OpenStack resources
+  ansible.builtin.import_playbook: postdeploy_openstack.yml

--- a/playbooks/postdeploy_api.yml
+++ b/playbooks/postdeploy_api.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run post-deploy tasks for Distil API
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Run post-deploy tasks for Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: postdeploy

--- a/playbooks/postdeploy_base.yml
+++ b/playbooks/postdeploy_base.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run post-deploy tasks for Distil Base
+  hosts: distil:distil_api:distil_manage:distil_exporter:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Run post-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: postdeploy

--- a/playbooks/postdeploy_collector.yml
+++ b/playbooks/postdeploy_collector.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run post-deploy tasks for Distil Collector
+  hosts: distil:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Run post-deploy tasks for Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: postdeploy

--- a/playbooks/postdeploy_exporter.yml
+++ b/playbooks/postdeploy_exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run post-deploy tasks for Distil Exporter
+  hosts: distil:distil_exporter
+  become: true
+  serial: 1
+  tasks:
+    - name: Run post-deploy tasks for Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: postdeploy

--- a/playbooks/postdeploy_manage.yml
+++ b/playbooks/postdeploy_manage.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run post-deploy tasks for Distil Manage
+  hosts: distil:distil_manage
+  become: true
+  serial: 1
+  tasks:
+    - name: Run post-deploy tasks for Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: postdeploy

--- a/playbooks/postdeploy_openstack.yml
+++ b/playbooks/postdeploy_openstack.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run post-deploy tasks for Distil OpenStack resources
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Run post-deploy tasks for Distil Keystone resources
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.keystone
+        tasks_from: postdeploy

--- a/playbooks/predeploy.yml
+++ b/playbooks/predeploy.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Run pre-deploy tasks for Distil Collector
+  ansible.builtin.import_playbook: predeploy_collector.yml
+
+- name: Run pre-deploy tasks for Distil Exporter
+  ansible.builtin.import_playbook: predeploy_exporter.yml
+
+- name: Run pre-deploy tasks for Distil API
+  ansible.builtin.import_playbook: predeploy_api.yml
+
+- name: Run pre-deploy tasks for Distil Manage
+  ansible.builtin.import_playbook: predeploy_manage.yml
+
+- name: Run pre-deploy tasks for Distil OpenStack resources
+  ansible.builtin.import_playbook: predeploy_openstack.yml

--- a/playbooks/predeploy_api.yml
+++ b/playbooks/predeploy_api.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run pre-deploy tasks for Distil API
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: predeploy

--- a/playbooks/predeploy_base.yml
+++ b/playbooks/predeploy_base.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run pre-deploy tasks for Distil Base
+  hosts: distil:distil_api:distil_manage:distil_exporter:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: predeploy

--- a/playbooks/predeploy_collector.yml
+++ b/playbooks/predeploy_collector.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run pre-deploy tasks for Distil Collector
+  hosts: distil:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: predeploy

--- a/playbooks/predeploy_exporter.yml
+++ b/playbooks/predeploy_exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run pre-deploy tasks for Distil Exporter
+  hosts: distil:distil_exporter
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: predeploy

--- a/playbooks/predeploy_manage.yml
+++ b/playbooks/predeploy_manage.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run pre-deploy tasks for Distil Manage
+  hosts: distil:distil_manage
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: predeploy

--- a/playbooks/predeploy_openstack.yml
+++ b/playbooks/predeploy_openstack.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Run pre-deploy tasks for Distil OpenStack resources
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Run pre-deploy tasks for Distil Keystone resources
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.keystone
+        tasks_from: predeploy

--- a/playbooks/stop.yml
+++ b/playbooks/stop.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Stop Distil Collector
+  ansible.builtin.import_playbook: stop_collector.yml
+
+- name: Stop Distil Exporter
+  ansible.builtin.import_playbook: stop_exporter.yml
+
+- name: Stop Distil API
+  ansible.builtin.import_playbook: stop_api.yml

--- a/playbooks/stop_api.yml
+++ b/playbooks/stop_api.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Stop Distil API
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Stop Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: stop

--- a/playbooks/stop_collector.yml
+++ b/playbooks/stop_collector.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Stop Distil Collector
+  hosts: distil:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Stop Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: stop

--- a/playbooks/stop_exporter.yml
+++ b/playbooks/stop_exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Stop Distil Exporter
+  hosts: distil:distil_exporter
+  become: true
+  serial: 1
+  tasks:
+    - name: Stop Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: stop

--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Uninstall Distil Collector
+  ansible.builtin.import_playbook: uninstall_collector.yml
+
+- name: Uninstall Distil Exporter
+  ansible.builtin.import_playbook: uninstall_exporter.yml
+
+- name: Uninstall Distil API
+  ansible.builtin.import_playbook: uninstall_api.yml
+
+- name: Uninstall Distil Manage
+  ansible.builtin.import_playbook: uninstall_manage.yml
+
+- name: Uninstall Distil Base
+  ansible.builtin.import_playbook: uninstall_base.yml
+
+- name: Uninstall Distil OpenStack resources
+  ansible.builtin.import_playbook: uninstall_openstack.yml

--- a/playbooks/uninstall_api.yml
+++ b/playbooks/uninstall_api.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Uninstall Distil Exporter
+  hosts: distil:distil_api
+  become: true
+  serial: 1
+  tasks:
+    - name: Uninstall Distil API
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.api
+        tasks_from: uninstall

--- a/playbooks/uninstall_base.yml
+++ b/playbooks/uninstall_base.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Uninstall Distil Base
+  hosts: distil:distil_api:distil_manage:distil_exporter:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Uninstall Distil Base
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.base
+        tasks_from: uninstall

--- a/playbooks/uninstall_collector.yml
+++ b/playbooks/uninstall_collector.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Uninstall Distil Collector
+  hosts: distil:distil_collector
+  become: true
+  serial: 1
+  tasks:
+    - name: Uninstall Distil Collector
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.collector
+        tasks_from: uninstall

--- a/playbooks/uninstall_exporter.yml
+++ b/playbooks/uninstall_exporter.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Uninstall Distil Exporter
+  hosts: distil:distil_exporter
+  become: true
+  serial: 1
+  tasks:
+    - name: Uninstall Distil Exporter
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.exporter
+        tasks_from: uninstall

--- a/playbooks/uninstall_manage.yml
+++ b/playbooks/uninstall_manage.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Uninstall Distil Manage
+  hosts: distil:distil_manage
+  become: true
+  serial: 1
+  tasks:
+    - name: Uninstall Distil Manage
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.manage
+        tasks_from: uninstall

--- a/playbooks/uninstall_openstack.yml
+++ b/playbooks/uninstall_openstack.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Uninstall Distil OpenStack resources
+  hosts: localhost
+  gather_facts: false
+  become: false  # Don't escalate on localhost.
+  tasks:
+    - name: Uninstall Distil Keystone resources
+      ansible.builtin.include_role:
+        name: catalystcloud.distil.keystone
+        tasks_from: uninstall
+      when: distil_keystone_enable | default(True)

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Run pre-deploy tasks for Distil
+  ansible.builtin.import_playbook: predeploy.yml
+
+- name: Disable Distil
+  ansible.builtin.import_playbook: disable.yml
+
+- name: Install Distil
+  ansible.builtin.import_playbook: install.yml
+
+- name: Migrate Distil
+  ansible.builtin.import_playbook: migrate.yml
+
+- name: Enable Distil
+  ansible.builtin.import_playbook: enable.yml
+
+- name: Run post-deploy tasks for Distil
+  ansible.builtin.import_playbook: postdeploy.yml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+ansible==9.6.0
+ansible-compat==24.5.1
+ansible-core==2.17.0
+ansible-lint==24.5.0
+antsibull-changelog==0.27.0
+molecule==24.2.1
+openstacksdk==3.1.0
+pre-commit==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible==9.6.0
 ansible-compat==24.5.1
-ansible-core==2.17.0
+ansible-core==2.16.7
 ansible-lint==24.5.0
 antsibull-changelog==0.27.0
 molecule==24.2.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,5 @@
+---
+
+collections:
+  - name: community.crypto
+    version: 2.20.0

--- a/roles/api/README.md
+++ b/roles/api/README.md
@@ -1,0 +1,28 @@
+# `catalystcloud.distil.api`
+
+An Ansible role for managing Distil API.
+
+Distil API runs the OpenStack rating service API, which can be queried
+using the `openstack rating` commands provided by the
+[`python-distilclient`](https://pypi.org/project/python-distilclient) package,
+or via the dashboard using the [Distil UI](https://opendev.org/x/distil-ui) plugin for Horizon.
+
+Distil API uses a configurable ERP driver for a number of functions:
+
+* Querying for invoices from previous months
+* Fetching a list of products with prices, for generating the current month's quotations
+
+The Ansible collection configures Distil to use the `jsonfile` ERP driver by default.
+This reads a list of products and prices from a `products.json` file that is installed
+with the configuration, and allows Distil to work in test environments without a functioning
+Odoo installation.
+
+To use Distil with Odoo, the ERP driver will need to be changed to `odoo` using the inventory,
+as documented below.
+
+By default, a service container named `distil-api` will be created on the host.
+
+Distil API is run as a WSGI app within [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest),
+serving HTTPS to port 9999 by default, with 3 workers and 3 concurrent threads per worker.
+
+For more information, check the documentation for the `catalystcloud.distil` collection.

--- a/roles/api/defaults/main.yml
+++ b/roles/api/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+
+# Base subdirectory for this particular service.
+distil_api_base_dir: "{{ distil_base_dir }}/api"
+
+# Project name to use when managing service containers via Docker Compose.
+distil_api_compose_project_name: "distil-api"
+
+# Container name for the Distil API service. Set to null to auto-generate.
+distil_api_container_name: "distil-api"
+
+# The time to wait for Distil API to open its ports during startup, in seconds.
+distil_api_start_timeout: 300
+
+# Distil API external hostname, bind address and port are in the common role.

--- a/roles/api/defaults/main.yml
+++ b/roles/api/defaults/main.yml
@@ -9,6 +9,13 @@ distil_api_compose_project_name: "distil-api"
 # Container name for the Distil API service. Set to null to auto-generate.
 distil_api_container_name: "distil-api"
 
+# Service-specific SSL settings.
+# By default, use the global Distil values.
+distil_api_ssl_enable: "{{ distil_ssl_enable }}"
+distil_api_ssl_cert: "{{ distil_ssl_cert }}"
+distil_api_ssl_key: "{{ distil_ssl_key }}"
+distil_api_ssl_cacert: "{{ distil_ssl_cacert }}"
+
 # The time to wait for Distil API to open its ports during startup, in seconds.
 distil_api_start_timeout: 300
 

--- a/roles/api/files/distil-api.wsgi
+++ b/roles/api/files/distil-api.wsgi
@@ -1,0 +1,3 @@
+from distil.api import app
+
+application = app.make_app(['--config-file', '/etc/distil/distil.conf'])

--- a/roles/api/tasks/disable.yml
+++ b/roles/api/tasks/disable.yml
@@ -14,7 +14,6 @@
     project_name: "{{ distil_api_compose_project_name }}"
     project_src: "{{ distil_api_base_dir }}"
     state: absent
-    remove_images: false
     remove_volumes: false
     remove_orphans: false
   when: distil_api_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/api/tasks/disable.yml
+++ b/roles/api/tasks/disable.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Check if the service compose file exists
+  ansible.builtin.stat:
+    path: "{{ distil_api_base_dir }}/docker-compose.yml"
+  register: distil_api_temp_dockercompose_yml
+
+- name: Destroy service containers (if the compose file exists)
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_api_compose_project_name }}"
+    project_src: "{{ distil_api_base_dir }}"
+    state: absent
+    remove_images: false
+    remove_volumes: false
+    remove_orphans: false
+  when: distil_api_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/api/tasks/enable.yml
+++ b/roles/api/tasks/enable.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Enable Distil API
+  ansible.builtin.include_tasks:
+    file: subtasks/enable.yml

--- a/roles/api/tasks/install.yml
+++ b/roles/api/tasks/install.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Create service directory
+  ansible.builtin.file:
+    path: "{{ distil_api_base_dir }}"
+    state: directory
+    owner: root
+    group: "{{ distil_docker_group }}"
+    mode: "0770"
+
+- name: Create service README file
+  ansible.builtin.template:
+    src: README.md.j2
+    dest: "{{ distil_api_base_dir }}/README.md"
+    owner: root
+    group: root
+    mode: "0640"
+
+- name: Create WSGI script file
+  ansible.builtin.copy:
+    src: distil-api.wsgi
+    dest: "{{ distil_api_base_dir }}/distil-api.wsgi"
+    owner: root
+    group: root
+    mode: "0644"
+  register: distil_api_temp_wsgi_file
+
+- name: Create service compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ distil_api_base_dir }}/docker-compose.yml"
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0640"
+
+- name: Mark service as changed (if mounted files are changed)
+  ansible.builtin.set_fact:
+    distil_api_temp_changed: "{{ distil_api_temp_wsgi_file.changed }}"

--- a/roles/api/tasks/install.yml
+++ b/roles/api/tasks/install.yml
@@ -37,6 +37,13 @@
     group: "{{ distil_user_group }}"
     mode: "0640"
 
+- name: Pull service containers
+  community.docker.docker_compose_v2_pull:
+    project_src: "{{ distil_api_base_dir }}"
+    files:
+      - docker-compose.yml
+  when: not ansible_check_mode
+
 - name: Mark service as changed (if mounted files are changed)
   ansible.builtin.set_fact:
     distil_api_temp_changed: "{{ distil_api_temp_wsgi_file.changed }}"

--- a/roles/api/tasks/main.yml
+++ b/roles/api/tasks/main.yml
@@ -9,9 +9,9 @@
     file: subtasks/enable.yml
   vars:
     distil_api_temp_pull: always
-    distil_api_temp_state: >-
+    distil_collector_temp_recreate: >-
       {{
-        'restarted'
+        'always'
         if (distil_base_temp_changed | default(False)) or distil_api_temp_changed
-        else 'present'
+        else 'auto'
       }}

--- a/roles/api/tasks/main.yml
+++ b/roles/api/tasks/main.yml
@@ -8,7 +8,6 @@
   ansible.builtin.include_tasks:
     file: subtasks/enable.yml
   vars:
-    distil_api_temp_pull: always
     distil_collector_temp_recreate: >-
       {{
         'always'

--- a/roles/api/tasks/main.yml
+++ b/roles/api/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Install Distil API
+  ansible.builtin.include_tasks:
+    file: install.yml
+
+- name: Enable Distil API (restart if mounted files changed, or image updated)
+  ansible.builtin.include_tasks:
+    file: subtasks/enable.yml
+  vars:
+    distil_api_temp_pull: always
+    distil_api_temp_state: >-
+      {{
+        'restarted'
+        if (distil_base_temp_changed | default(False)) or distil_api_temp_changed
+        else 'present'
+      }}

--- a/roles/api/tasks/postdeploy.yml
+++ b/roles/api/tasks/postdeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run after completing the deploy here.
+# Examples include cleaning up old service files.

--- a/roles/api/tasks/predeploy.yml
+++ b/roles/api/tasks/predeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run before starting the deploy here.
+# Examples include stopping and disabling old services.

--- a/roles/api/tasks/stop.yml
+++ b/roles/api/tasks/stop.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Check if the service compose file exists
+  ansible.builtin.stat:
+    path: "{{ distil_api_base_dir }}/docker-compose.yml"
+  register: distil_api_temp_dockercompose_yml
+
+- name: Stop service containers without destroying them (if the compose file exists)
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_api_compose_project_name }}"
+    project_src: "{{ distil_api_base_dir }}"
+    state: stopped
+  when: distil_api_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/api/tasks/stop.yml
+++ b/roles/api/tasks/stop.yml
@@ -11,7 +11,8 @@
 
 - name: Stop service containers without destroying them (if the compose file exists)
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_api_compose_project_name }}"
     project_src: "{{ distil_api_base_dir }}"
+    files:
+      - docker-compose.yml
     state: stopped
   when: distil_api_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/api/tasks/subtasks/enable.yml
+++ b/roles/api/tasks/subtasks/enable.yml
@@ -3,7 +3,7 @@
 - name: Start service containers
   community.docker.docker_compose_v2:
     project_src: "{{ distil_api_base_dir }}"
-    state: "{{ distil_api_temp_state | default('present') }}"
+    state: present
     pull: "{{ distil_api_temp_pull | default('missing') }}"
     recreate: "{{ distil_api_temp_recreate | default('auto') }}"
   when: not ansible_check_mode

--- a/roles/api/tasks/subtasks/enable.yml
+++ b/roles/api/tasks/subtasks/enable.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Start service containers
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_api_compose_project_name }}"
+    project_src: "{{ distil_api_base_dir }}"
+    state: "{{ distil_api_temp_state | default('present') }}"
+    pull: "{{ distil_api_temp_pull | default('missing') }}"
+    recreate: "{{ distil_api_temp_recreate | default('auto') }}"
+
+- name: Wait until access port is online
+  ansible.builtin.wait_for:
+    host: "{{ ansible_default_ipv4.address }}"
+    port: "{{ distil_api_port }}"
+    timeout: "{{ distil_api_start_timeout }}"
+  when: not ansible_check_mode

--- a/roles/api/tasks/subtasks/enable.yml
+++ b/roles/api/tasks/subtasks/enable.yml
@@ -7,6 +7,7 @@
     state: "{{ distil_api_temp_state | default('present') }}"
     pull: "{{ distil_api_temp_pull | default('missing') }}"
     recreate: "{{ distil_api_temp_recreate | default('auto') }}"
+  when: not ansible_check_mode
 
 - name: Wait until access port is online
   ansible.builtin.wait_for:

--- a/roles/api/tasks/subtasks/enable.yml
+++ b/roles/api/tasks/subtasks/enable.yml
@@ -2,7 +2,6 @@
 
 - name: Start service containers
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_api_compose_project_name }}"
     project_src: "{{ distil_api_base_dir }}"
     state: "{{ distil_api_temp_state | default('present') }}"
     pull: "{{ distil_api_temp_pull | default('missing') }}"

--- a/roles/api/tasks/subtasks/enable.yml
+++ b/roles/api/tasks/subtasks/enable.yml
@@ -3,8 +3,9 @@
 - name: Start service containers
   community.docker.docker_compose_v2:
     project_src: "{{ distil_api_base_dir }}"
+    files:
+      - docker-compose.yml
     state: present
-    pull: "{{ distil_api_temp_pull | default('missing') }}"
     recreate: "{{ distil_api_temp_recreate | default('auto') }}"
   when: not ansible_check_mode
 

--- a/roles/api/tasks/uninstall.yml
+++ b/roles/api/tasks/uninstall.yml
@@ -11,8 +11,9 @@
 
 - name: Destroy service containers and remove volumes/images (if the compose file exists)
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_api_compose_project_name }}"
     project_src: "{{ distil_api_base_dir }}"
+    files:
+      - docker-compose.yml
     state: absent
     remove_images: all
     remove_volumes: true

--- a/roles/api/tasks/uninstall.yml
+++ b/roles/api/tasks/uninstall.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Check if the service compose file exists
+  ansible.builtin.stat:
+    path: "{{ distil_api_base_dir }}/docker-compose.yml"
+  register: distil_api_temp_dockercompose_yml
+
+- name: Destroy service containers and remove volumes/images (if the compose file exists)
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_api_compose_project_name }}"
+    project_src: "{{ distil_api_base_dir }}"
+    state: absent
+    remove_images: true
+    remove_volumes: true
+    remove_orphans: false
+  when: distil_api_temp_dockercompose_yml.stat.exists | default(False)
+
+- name: Delete service directory
+  ansible.builtin.file:
+    path: "{{ distil_api_base_dir }}"
+    state: absent

--- a/roles/api/tasks/uninstall.yml
+++ b/roles/api/tasks/uninstall.yml
@@ -14,7 +14,7 @@
     project_name: "{{ distil_api_compose_project_name }}"
     project_src: "{{ distil_api_base_dir }}"
     state: absent
-    remove_images: true
+    remove_images: all
     remove_volumes: true
     remove_orphans: false
   when: distil_api_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/api/templates/README.md.j2
+++ b/roles/api/templates/README.md.j2
@@ -1,0 +1,43 @@
+# Distil API
+
+All commands should be run from the service directory.
+
+```bash
+cd {{ distil_api_base_dir }}
+```
+
+## Enable
+
+Run the following command to start the service container (if not already running).
+The container will run automatically on startup.
+
+```bash
+docker compose up -d
+```
+
+## Stop
+
+Run the following command to temporarily stop the service container, if it is running.
+Note that this is only a temporary stop. If the host is rebooted, the container will restart.
+
+```bash
+docker compose stop
+```
+
+## Disable
+
+Run the following command to stop and destroy the service container, so it will not
+start automatically on boot.
+
+```bash
+docker compose down
+```
+
+## Checks
+
+You can use any of the following commands to check service status.
+
+```bash
+docker compose top
+docker compose ps
+```

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -47,7 +47,7 @@ services:
       - UWSGI_WORKERS=3
       - UWSGI_THREADS=3
       - UWSGI_LOGTO=/var/log/distil/distil-api-wsgi.log
-      - UWSGI_LOGFILE_CHMOD=644
+      - UWSGI_LOGFILE_CHMOD={{ distil_log_file_mode }}
       - UWSGI_DIE_ON_TERM=true
       - UWSGI_SHOW_CONFIG=true
       - UWSGI_MASTER=true

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -1,7 +1,7 @@
 ---
 
 services:
-  {{ distil_api_container_name | default('distil-api', true) }}:
+  {{ distil_api_container_name | default('distil-api', True) }}:
 {% if distil_api_container_name %}
     container_name: {{ distil_api_container_name }}
 {% endif %}

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -47,7 +47,7 @@ services:
       - UWSGI_WORKERS=3
       - UWSGI_THREADS=3
       - UWSGI_LOGTO=/var/log/distil/distil-api-wsgi.log
-      - UWSGI_LOGFILE_CHMOD={{ distil_log_file_mode }}
+      - UWSGI_LOGFILE_CHMOD=644
       - UWSGI_DIE_ON_TERM=true
       - UWSGI_SHOW_CONFIG=true
       - UWSGI_MASTER=true

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -26,24 +26,24 @@ services:
         read_only: false
       - type: bind
         source: {{ distil_ssl_cert }}
-        target: {{ distil_ssl_cert }}
+        target: /opt/distil/ssl/cert.crt
         read_only: true
       - type: bind
         source: {{ distil_ssl_key }}
-        target: {{ distil_ssl_key }}
+        target: /opt/distil/ssl/cert.key
         read_only: true
       - type: bind
         source: {{ distil_ssl_cacert }}
-        target: {{ distil_ssl_cacert }}
+        target: /opt/distil/ssl/ca.crt
         read_only: true
       - type: bind
         source: {{ distil_api_base_dir }}/distil-api.wsgi
-        target: /opt/distil/distil-api.wsgi
+        target: /opt/distil/wsgi/distil-api
         read_only: true
     environment:
-      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+      - REQUESTS_CA_BUNDLE=/opt/distil/ssl/ca.crt
       - UWSGI_WSGI_ENV_BEHAVIOR=holy
-      - UWSGI_HTTPS={{ distil_api_address }}:{{ distil_api_port }},{{ distil_ssl_cert }},{{ distil_ssl_key }},HIGH
+      - UWSGI_HTTPS={{ distil_api_address }}:{{ distil_api_port }},/opt/distil/ssl/cert.crt,/opt/distil/ssl/cert.key,HIGH
       - UWSGI_HTTP_AUTO_CHUNKED=1
       - UWSGI_HTTP_KEEPALIVE=1
       - UWSGI_WORKERS=3
@@ -57,4 +57,4 @@ services:
     entrypoint:
       - uwsgi
     command:
-      - --wsgi-file=/opt/distil/distil-api.wsgi
+      - --wsgi-file=/opt/distil/wsgi/distil-api

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -24,16 +24,18 @@ services:
         source: {{ distil_log_dir }}
         target: /var/log/distil
         read_only: false
+{% if distil_api_ssl_enable %}
       - type: bind
-        source: {{ distil_ssl_cert }}
+        source: {{ distil_api_ssl_cert }}
         target: /opt/distil/ssl/cert.crt
         read_only: true
       - type: bind
-        source: {{ distil_ssl_key }}
+        source: {{ distil_api_ssl_key }}
         target: /opt/distil/ssl/cert.key
         read_only: true
+{% endif %}
       - type: bind
-        source: {{ distil_ssl_cacert }}
+        source: {{ distil_api_ssl_cacert }}
         target: /opt/distil/ssl/ca.crt
         read_only: true
       - type: bind
@@ -43,7 +45,11 @@ services:
     environment:
       - REQUESTS_CA_BUNDLE=/opt/distil/ssl/ca.crt
       - UWSGI_WSGI_ENV_BEHAVIOR=holy
+{% if distil_api_ssl_enable %}
       - UWSGI_HTTPS={{ distil_api_address }}:{{ distil_api_port }},/opt/distil/ssl/cert.crt,/opt/distil/ssl/cert.key,HIGH
+{% else %}
+      - UWSGI_HTTP={{ distil_api_address }}:{{ distil_api_port }},HIGH
+{% endif %}
       - UWSGI_HTTP_AUTO_CHUNKED=1
       - UWSGI_HTTP_KEEPALIVE=1
       - UWSGI_WORKERS=3

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -1,5 +1,7 @@
 ---
 
+name: "{{ distil_api_compose_project_name }}"
+
 services:
   {{ distil_api_container_name | default('distil-api', True) }}:
 {% if distil_api_container_name %}

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -11,7 +11,7 @@ services:
     user: "{{ distil_user_uid }}:{{ distil_user_gid }}"
     volumes:
       - type: bind
-        source: {{ distil_etc_dir }}
+        source: {{ distil_config_dir }}
         target: /etc/distil
         read_only: true
       - type: bind

--- a/roles/api/templates/docker-compose.yml.j2
+++ b/roles/api/templates/docker-compose.yml.j2
@@ -1,0 +1,58 @@
+---
+
+services:
+  {{ distil_api_container_name | default('distil-api', true) }}:
+{% if distil_api_container_name %}
+    container_name: {{ distil_api_container_name }}
+{% endif %}
+    image: {{ distil_container_image_uri }}:{{ distil_container_image_tag }}
+    restart: always
+    network_mode: host
+    user: "{{ distil_user_uid }}:{{ distil_user_gid }}"
+    volumes:
+      - type: bind
+        source: {{ distil_etc_dir }}
+        target: /etc/distil
+        read_only: true
+      - type: bind
+        source: {{ distil_lib_dir }}
+        target: /var/lib/distil
+        read_only: false
+      - type: bind
+        source: {{ distil_log_dir }}
+        target: /var/log/distil
+        read_only: false
+      - type: bind
+        source: {{ distil_ssl_cert }}
+        target: {{ distil_ssl_cert }}
+        read_only: true
+      - type: bind
+        source: {{ distil_ssl_key }}
+        target: {{ distil_ssl_key }}
+        read_only: true
+      - type: bind
+        source: {{ distil_ssl_cacert }}
+        target: {{ distil_ssl_cacert }}
+        read_only: true
+      - type: bind
+        source: {{ distil_api_base_dir }}/distil-api.wsgi
+        target: /opt/distil/distil-api.wsgi
+        read_only: true
+    environment:
+      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+      - UWSGI_WSGI_ENV_BEHAVIOR=holy
+      - UWSGI_HTTPS={{ distil_api_address }}:{{ distil_api_port }},{{ distil_ssl_cert }},{{ distil_ssl_key }},HIGH
+      - UWSGI_HTTP_AUTO_CHUNKED=1
+      - UWSGI_HTTP_KEEPALIVE=1
+      - UWSGI_WORKERS=3
+      - UWSGI_THREADS=3
+      - UWSGI_LOGTO=/var/log/distil/distil-api-wsgi.log
+      - UWSGI_LOGFILE_CHMOD=644
+      - UWSGI_DIE_ON_TERM=true
+      - UWSGI_SHOW_CONFIG=true
+      - UWSGI_MASTER=true
+      - UWSGI_MAX_REQUESTS=1000
+    entrypoint:
+      - uwsgi
+    command:
+      - --wsgi-file=/opt/distil/distil-api.wsgi

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -1,0 +1,5 @@
+# `catalystcloud.distil.base`
+
+An Ansible role for managing service directories and files used by each Distil service.
+
+For more information, check the documentation for the `catalystcloud.distil` collection.

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+
+# A list of additional groups to add the Distil service user to.
+distil_user_groups: []
+
+# The location to install the Distil logrotate configuration file.
+distil_logrotate_file: "/etc/logrotate.d/distil-logs"
+
+distil_erp_driver: "jsonfile"  # Available drivers: jsonfile, odoo
+
+# distil_api_address is managed by the common role.
+# distil_api_port is managed by the common role.
+distil_api_ignore_products_in_quotations: []  # Used when services are collected, but not yet billed.
+
+distil_jsonfile_tax_rate: 0  # Percentage in decimal form
+distil_jsonfile_regions:
+  - "{{ distil_openstack_region }}"
+
+distil_odoo_version: null
+distil_odoo_hostname: "localhost"
+distil_odoo_port: 8069
+distil_odoo_protocol: "jsonrpc"
+distil_odoo_database: "openstack"
+distil_odoo_username: "openstack"
+distil_odoo_password: "123456"
+distil_odoo_region_mapping: {}  # Key is region name in OpenStack, value is region name in Odoo.
+distil_odoo_licensed_os_distros: []
+distil_odoo_extra_product_categories:
+  - "Database"
+  - "COE"
+distil_odoo_invisible_products: []

--- a/roles/base/files/distil-logs.logrotate
+++ b/roles/base/files/distil-logs.logrotate
@@ -1,0 +1,9 @@
+/var/log/distil/*.log {
+  compress
+  copytruncate
+  delaycompress
+  missingok
+  notifempty
+  daily
+  rotate 5
+}

--- a/roles/base/files/meter_mappings.yml
+++ b/roles/base/files/meter_mappings.yml
@@ -1,0 +1,273 @@
+---
+
+-
+  # meter name as seen in ceilometer
+  meter: instance
+  # type of resource it maps to (seen on sales order)
+  type: Virtual Machine
+  # which transformer to use
+  transformer: uptime
+  # what unit type is coming in via the meter
+  unit: second
+  metadata:
+    name:
+      sources:
+        # which keys to search for in the ceilometer entry metadata
+        # this can be more than one as metadata is inconsistent between
+        # source types
+        - display_name
+    availability zone:
+      sources:
+        - OS-EXT-AZ:availability_zone
+    host:
+      sources:
+        - host
+-
+  meter: ip.floating
+  service: n1.ipv4
+  type: Floating IP
+  transformer: max
+  unit: hour
+  metadata:
+    ip address:
+      sources:
+        - floating_ip_address
+-
+  meter: volume.size
+  service: b1.standard
+  type: Volume
+  transformer: blockstoragemax
+  unit: gigabyte
+  metadata:
+    name:
+      sources:
+        - name
+        - volume_id
+    availability zone:
+      sources:
+        - availability_zone
+-
+  meter: instance
+  service: b1.standard
+  type: Volume
+  transformer: fromimage
+  unit: gigabyte
+  # if true allows id pattern, and metadata patterns
+  transform_info: true
+  # allows us to put the id into a pattern,
+  # only if transform_info is true,
+  # such as to append something to it
+  res_id_template: "%s-root_disk"
+  metadata:
+    name:
+      sources:
+        - display_name
+      template: "%s - root disk"
+    availability zone:
+      sources:
+        - availability_zone
+        - OS-EXT-AZ:availability_zone
+-
+  meter: image.size
+  service: b1.standard
+  type: Image
+  transformer: max
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+        - properties.image_name
+-
+  meter: traffic.outbound.international
+  service: n1.international-out
+  type: Outbound International Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: traffic.inbound.international
+  service: n1.international-in
+  type: Inbound International Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: traffic.outbound.national
+  service: n1.national-out
+  type: Outbound National Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: traffic.inbound.national
+  service: n1.national-in
+  type: Inbound National Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: network.services.vpn
+  service: n1.vpn
+  type: VPN
+  transformer: networkservice
+  unit: hour
+  metadata:
+    name:
+      sources:
+        - name
+    subnet:
+      sources:
+        - subnet_id
+-
+  meter: network
+  service: n1.network
+  type: Network
+  transformer: max
+  unit: hour
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: router
+  service: n1.router
+  type: Router
+  transformer: max
+  unit: hour
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: storage.containers.objects.size
+  service: o1.standard
+  type: Object Storage Container
+  transformer: objectstoragemax
+  unit: byte
+  # NOTE(flwang): Nothing in resource_metadata from ceilometer actually.
+  # But to avoid any unnecessary issue and keeping consistency. Just keep
+  # 'name' as default key.
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: storage.objects.download.size.national
+  service: o1.national-out
+  type: Swift Outbound National Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: storage.objects.upload.size.national
+  service: o1.national-in
+  type: Swift Inbound National Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: storage.objects.download.size.international
+  service: o1.international-out
+  type: Swift Outbound International Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: storage.objects.upload.size.international
+  service: o1.international-in
+  type: Swift Inbound International Traffic
+  transformer: sum
+  unit: byte
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: network.services.octavia.loadbalancer
+  service: n1.lb
+  type: LBaaS
+  transformer: networkservice
+  unit: hour
+  metadata:
+    name:
+      sources:
+        - name
+
+-
+  meter: database.instance
+  service: b1.standard
+  type: Database Volume
+  transformer: databasevolumemax
+  unit: gigabyte
+  res_id_template: "%s-volume"
+  metadata:
+    name:
+      sources:
+        - name
+      template: "%s - volume"
+    datastore:
+      sources:
+        - datastore
+
+-
+  meter: database.instance
+  type: Database Instance
+  transformer: databasemanagementuptime
+  unit: second
+  metadata:
+    name:
+      sources:
+        - name
+    datastore:
+      sources:
+        - datastore
+-
+  meter: cim.coe.cluster
+  service: coe1.cluster
+  type: COE Cluster
+  unit: hour
+  transformer: numbool
+  filters:
+    - "!contains(['CREATE_IN_PROGRESS', 'CREATE_FAILED', 'DELETE_FAILED', 'DELETE_COMPLETE'], metadata.status)"
+  metadata:
+    name:
+      sources:
+        - name
+-
+  meter: cim.coe.cluster
+  service: coe1.worker
+  type: COE Worker
+  unit: worker
+  transformer: max
+  volume:
+    source: metadata.node_count
+  filters:
+    - "!contains(['CREATE_IN_PROGRESS', 'CREATE_FAILED', 'DELETE_FAILED', 'DELETE_COMPLETE'], metadata.status)"
+  res_id_template: "%s-worker"
+  metadata:
+    name:
+      sources:
+        - name
+      template: "%s - worker"

--- a/roles/base/files/policy.yaml
+++ b/roles/base/files/policy.yaml
@@ -1,0 +1,12 @@
+---
+
+context_is_admin: 'role:admin'
+responsible_for_billing: 'role:_member_ or role:billing or role:project_admin or role:project_mod'
+admin_or_owner: 'role:admin or (project_id:%(project_id)s and rule:responsible_for_billing)'
+default: 'rule:admin_or_owner'
+
+'rating:credits:get': 'rule:admin_or_owner'
+'rating:measurements:get': 'rule:admin_or_owner'
+'rating:invoices:get': 'rule:admin_or_owner'
+'rating:quotations:get': 'rule:admin_or_owner'
+'health:get': 'rule:context_is_admin'

--- a/roles/base/files/transformer.yml
+++ b/roles/base/files/transformer.yml
@@ -1,0 +1,56 @@
+---
+
+uptime:
+  # states marked as "billable" for VMs.
+  tracked_states:
+    - active
+    - paused
+    - rescue
+    - rescued
+    - resize
+    - resized
+    - verify_resize
+    - suspended
+    - shutoff
+    - stopped
+fromimage:
+  service: b1.standard
+  # What metadata values to check
+  md_keys:
+    - image_ref
+    - image_meta.base_image_ref
+  none_values:
+    - None
+    - ""
+  # where to get volume size from
+  size_keys:
+    - root_gb
+databaseuptime:
+  tracked_states:
+    - HEALTHY
+    - ACTIVE
+    - BLOCKED
+    - REBOOT
+    - RESIZE
+    - BACKUP
+    - SHUTDOWN
+    - RESTART_REQUIRED
+    - PROMOTE
+    - EJECT
+    - UPGRADE
+    - DETACH
+databasemanagementuptime:
+  prefix: "db."
+  tracked_states:
+    - HEALTHY
+    - ACTIVE
+    - BLOCKED
+    - REBOOT
+    - RESIZE
+    - BACKUP
+    - SHUTDOWN
+    - RESTART_REQUIRED
+    - PROMOTE
+    - EJECT
+    - UPGRADE
+    - DETACH

--- a/roles/base/tasks/install.yml
+++ b/roles/base/tasks/install.yml
@@ -1,0 +1,150 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Create service group with fixed GID
+  ansible.builtin.group:
+    name: "{{ distil_user_group }}"
+    gid: "{{ distil_user_gid }}"
+    system: true
+
+- name: Create service user with fixed UID/GID
+  ansible.builtin.user:
+    name: "{{ distil_user_name }}"
+    uid: "{{ distil_user_uid }}"
+    group: "{{ distil_user_group }}"
+    groups: "{{ distil_user_groups }}"
+    system: true
+    home: "{{ distil_lib_dir }}"
+    create_home: false
+    shell: /bin/false
+
+- name: Create base directory
+  ansible.builtin.file:
+    path: "{{ distil_base_dir }}"
+    state: directory
+    owner: root
+    group: "{{ distil_docker_group }}"
+    mode: "0750"
+
+- name: Create configuration directory
+  ansible.builtin.file:
+    path: "{{ distil_config_dir }}"
+    state: directory
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0750"
+
+- name: Create runtime directory
+  ansible.builtin.file:
+    path: "{{ distil_lib_dir }}"
+    state: directory
+    owner: "{{ distil_user_name }}"
+    group: "{{ distil_user_group }}"
+    mode: "0770"
+
+- name: Create logging directory
+  ansible.builtin.file:
+    path: "{{ distil_log_dir }}"
+    state: directory
+    owner: "{{ distil_user_name }}"
+    group: "{{ distil_log_group }}"
+    mode: "{{ distil_log_dir_mode }}"
+
+- name: Recursively set log subdirectory permissions
+  ansible.builtin.command:
+    argv:
+      - find
+      - "{{ distil_log_dir }}"
+      - -type
+      - d
+      - -exec
+      - chmod
+      - --changes
+      - "{{ distil_log_dir_mode }}"
+      - '{}'
+      - '\;'
+  register: distil_base_temp_chmod_dirs
+  changed_when: "'changed' in distil_base_temp_chmod_dirs.stdout"
+
+- name: Recursively set log file permissions
+  ansible.builtin.command:
+    argv:
+      - find
+      - "{{ distil_log_dir }}"
+      - -type
+      - f
+      - exec
+      - chmod
+      - --changes
+      - "{{ distil_log_file_mode }}"
+      - '{}'
+      - '\;'
+  register: distil_base_temp_chmod_files
+  changed_when: "'changed' in distil_base_temp_chmod_files.stdout"
+
+- name: Create base configuration file (distil.conf)
+  ansible.builtin.template:
+    src: distil.conf.j2
+    dest: "{{ distil_config_dir }}/distil.conf"
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0640"
+  register: distil_base_temp_config_file
+
+- name: Create meter mappings file (meter_mappings.yml)
+  ansible.builtin.copy:
+    src: meter_mappings.yml
+    dest: "{{ distil_config_dir }}/meter_mappings.yml"
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0644"
+  register: distil_base_temp_metermappings_file
+
+- name: Create transformer file (transformer.yml)
+  ansible.builtin.copy:
+    src: transformer.yml
+    dest: "{{ distil_config_dir }}/transformer.yml"
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0644"
+  register: distil_base_temp_transformer_file
+
+- name: Create JSON file ERP driver products file (products.json)
+  ansible.builtin.template:
+    src: products.json.j2
+    dest: "{{ distil_config_dir }}/products.json"
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0644"
+  register: distil_base_temp_products_file
+
+- name: Create Keystone policy file (policy.yaml)
+  ansible.builtin.copy:
+    src: policy.yaml
+    dest: "{{ distil_config_dir }}/policy.yaml"
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0644"
+  register: distil_base_temp_policy_file
+
+- name: Create logrotate config file
+  ansible.builtin.copy:
+    src: distil-logs.logrotate
+    dest: /etc/logrotate.d/distil-logs
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Mark Distil Base as changed (if service files are changed)
+  ansible.builtin.set_fact:
+    distil_base_temp_changed: >-
+      {{
+        distil_base_temp_config_file.changed
+        or distil_base_temp_metermappings_file.changed
+        or distil_base_temp_transformer_file.changed
+        or distil_base_temp_products_file.changed
+        or distil_base_temp_policy_file.changed
+      }}

--- a/roles/base/tasks/install.yml
+++ b/roles/base/tasks/install.yml
@@ -50,7 +50,7 @@
     path: "{{ distil_log_dir }}"
     state: directory
     owner: "{{ distil_user_name }}"
-    group: "{{ distil_log_group }}"
+    group: "{{ distil_log_dir_group }}"
     mode: "{{ distil_log_dir_mode }}"
 
 - name: Recursively set log subdirectory permissions

--- a/roles/base/tasks/install.yml
+++ b/roles/base/tasks/install.yml
@@ -131,8 +131,8 @@
   register: distil_base_temp_policy_file
 
 - name: Create logrotate config file
-  ansible.builtin.copy:
-    src: distil-logs.logrotate
+  ansible.builtin.template:
+    src: distil-logs.logrotate.j2
     dest: /etc/logrotate.d/distil-logs
     owner: root
     group: root

--- a/roles/base/tasks/install.yml
+++ b/roles/base/tasks/install.yml
@@ -61,7 +61,7 @@
 
 - name: Recursively set log file permissions
   ansible.builtin.command:
-    cmd: 'find "{{ distil_log_dir }}" -type f -exec chmod --changes {{ distil_log_file_mode }} {} \;'
+    cmd: 'find "{{ distil_log_dir }}" -type f -exec chmod --changes 644 {} \;'
   register: distil_base_temp_chmod_files
   changed_when: "'changed' in distil_base_temp_chmod_files.stdout"
 

--- a/roles/base/tasks/install.yml
+++ b/roles/base/tasks/install.yml
@@ -55,33 +55,13 @@
 
 - name: Recursively set log subdirectory permissions
   ansible.builtin.command:
-    argv:
-      - find
-      - "{{ distil_log_dir }}"
-      - -type
-      - d
-      - -exec
-      - chmod
-      - --changes
-      - "{{ distil_log_dir_mode }}"
-      - '{}'
-      - '\;'
+    cmd: 'find "{{ distil_log_dir }}" -type d -exec chmod --changes {{ distil_log_dir_mode }} {} \;'
   register: distil_base_temp_chmod_dirs
   changed_when: "'changed' in distil_base_temp_chmod_dirs.stdout"
 
 - name: Recursively set log file permissions
   ansible.builtin.command:
-    argv:
-      - find
-      - "{{ distil_log_dir }}"
-      - -type
-      - f
-      - exec
-      - chmod
-      - --changes
-      - "{{ distil_log_file_mode }}"
-      - '{}'
-      - '\;'
+    cmd: 'find "{{ distil_log_dir }}" -type f -exec chmod --changes {{ distil_log_file_mode }} {} \;'
   register: distil_base_temp_chmod_files
   changed_when: "'changed' in distil_base_temp_chmod_files.stdout"
 

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Install Distil Base
+  ansible.builtin.include_tasks:
+    file: install.yml

--- a/roles/base/tasks/postdeploy.yml
+++ b/roles/base/tasks/postdeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run after completing the deploy here.
+# Examples include cleaning up old service files.

--- a/roles/base/tasks/predeploy.yml
+++ b/roles/base/tasks/predeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run before starting the deploy here.
+# Examples include stopping and disabling old services.

--- a/roles/base/tasks/uninstall.yml
+++ b/roles/base/tasks/uninstall.yml
@@ -1,0 +1,40 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Delete logrotate config file
+  ansible.builtin.file:
+    path: "{{ distil_logrotate_file }}"
+    state: absent
+
+- name: Delete logging directory
+  ansible.builtin.file:
+    path: "{{ distil_log_dir }}"
+    state: absent
+
+- name: Delete runtime file folder
+  ansible.builtin.file:
+    path: /var/lib/distil
+    state: absent
+
+- name: Delete Docker Compose directory
+  ansible.builtin.file:
+    path: /docker/compose/distil
+    state: absent
+
+- name: Delete base directory
+  ansible.builtin.file:
+    path: "{{ distil_base_dir }}"
+    state: absent
+
+- name: Delete service user
+  ansible.builtin.user:
+    name: distil
+    state: absent
+
+- name: Delete service group
+  ansible.builtin.group:
+    name: distil
+    state: absent

--- a/roles/base/templates/distil-logs.logrotate.j2
+++ b/roles/base/templates/distil-logs.logrotate.j2
@@ -1,4 +1,4 @@
-/var/log/distil/*.log {
+{{ distil_log_dir }}/*.log {
   compress
   copytruncate
   delaycompress

--- a/roles/base/templates/distil.conf.j2
+++ b/roles/base/templates/distil.conf.j2
@@ -1,0 +1,70 @@
+[DEFAULT]
+# Enable verbose logging output (log level set to `DEBUG`).
+# NOTE(callumdickinson): Avoid enabling `debug` in production,
+# until an upstream fix to avoid logging the ERP password has been made to odoorpc.
+# https://github.com/OCA/odoorpc/issues/70
+debug = false
+# Distil service logging configuration.
+log_dir = /var/log/distil
+# Distil service timezone.
+timezone = {{ distil_timezone }}
+# ERP driver to use when communicating with Distil.
+erp_driver = {{ distil_erp_driver }}
+# Distil API bind address and port.
+# Only used when using the `distil-api` command directly (for development purposes only).
+host = {{ distil_api_address }}
+port = {{ distil_api_port }}
+
+[cache]
+enabled = true
+backend = dogpile.cache.memory
+expiration_time = 86400
+
+[database]
+connection = {{ distil_database_connection_url }}
+backend = sqlalchemy
+
+[jsonfile]
+products_file_path = /etc/distil/products.json
+tax_rate = {{ distil_jsonfile_tax_rate }}
+{% if distil_api_ignore_products_in_quotations %}
+ignore_products_in_quotations = {{ distil_api_ignore_products_in_quotations | join(", ") }}
+{% else %}
+# ignore_products_in_quotations =
+{% endif %}
+
+[keystone_authtoken]
+auth_type = password
+auth_url = {{ distil_keystone_auth_url_full }}
+username = {{ distil_keystone_user_name }}
+password = {{ distil_keystone_user_password }}
+project_name = {{ distil_keystone_user_project }}
+user_domain_name = {{ distil_keystone_user_domain }}
+project_domain_name = {{ distil_keystone_user_domain }}
+region_name = {{ distil_openstack_region }}
+
+[odoo]
+{% if distil_odoo_version %}
+version = {{ distil_odoo_version }}
+{% else %}
+# version =
+{% endif %}
+hostname = {{ distil_odoo_hostname }}
+port = {{ distil_odoo_port }}
+protocol = {{ distil_odoo_protocol }}
+database = {{ distil_odoo_database }}
+user = {{ distil_odoo_username }}
+password = {{ distil_odoo_password }}
+{% if distil_odoo_region_mapping %}
+region_mapping = {{ distil_odoo_region_mapping.items() | map("join", ":") | join(",") }}
+{% endif %}
+licensed_os_distro_list = {{ distil_odoo_licensed_os_distros | join(", ") }}
+{% if distil_odoo_extra_product_categories %}
+extra_product_category_list = {{ distil_odoo_extra_product_categories | join(", ") }}
+{% endif %}
+invisible_products = {% if distil_odoo_invisible_products %}{{ distil_odoo_invisible_products | join(", ") }}{% endif +%}
+{% if distil_api_ignore_products_in_quotations %}
+ignore_products_in_quotations = {{ distil_api_ignore_products_in_quotations | join(", ") }}
+{% else %}
+# ignore_products_in_quotations =
+{% endif %}

--- a/roles/base/templates/products.json.j2
+++ b/roles/base/templates/products.json.j2
@@ -1,0 +1,1254 @@
+{
+{% for region in distil_jsonfile_regions %}
+    "{{ region }}": {
+        "compute": [
+            {
+                "name": "c1.c1r05",
+                "unit": "hour",
+                "rate": 0.017,
+                "description": "1 vCPU, 0.5 GB RAM"
+            },
+            {
+                "name": "c1.c1r05-windows",
+                "unit": "hour",
+                "rate": 0.0038,
+                "description": "1 vCPU, 0.5 GB RAM"
+            },
+            {
+                "name": "c1.c1r05-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.228,
+                "description": "1 vCPU, 0.5 GB RAM"
+            },
+            {
+                "name": "c1.c1r1",
+                "unit": "hour",
+                "rate": 0.039,
+                "description": "1 vCPU, 1 GB RAM"
+            },
+            {
+                "name": "c1.c1r1-windows",
+                "unit": "hour",
+                "rate": 0.0087,
+                "description": "1 vCPU, 1 GB RAM"
+            },
+            {
+               "name": "c1.c1r1-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.468,
+                "description": "1 vCPU, 1 GB RAM"
+            },
+            {
+                "name": "c1.c1r2",
+                "unit": "hour",
+                "rate": 0.062,
+                "description": "1 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c1r2-windows",
+                "unit": "hour",
+                "rate": 0.014,
+                "description": "1 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c1r2-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.555,
+                "description": "1 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c1r4",
+                "unit": "hour",
+                "rate": 0.098,
+                "description": "1 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c1r4-windows",
+                "unit": "hour",
+                "rate": 0.022,
+                "description": "1 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c1r4-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.877,
+                "description": "1 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c2r1",
+                "unit": "hour",
+                "rate": 0.070,
+                "description": "2 vCPU, 1 GB RAM"
+            },
+            {
+                "name": "c1.c2r1-windows",
+                "unit": "hour",
+                "rate": 0.016,
+                "description": "2 vCPU, 1 GB RAM"
+            },
+            {
+                "name": "c1.c2r1-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.627,
+                "description": "2 vCPU, 1 GB RAM"
+            },
+            {
+                "name": "c1.c2r2",
+                "unit": "hour",
+                "rate": 0.088,
+                "description": "2 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c2r2-windows",
+                "unit": "hour",
+                "rate": 0.020,
+                "description": "2 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c2r2-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.788,
+                "description": "2 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c2r4",
+                "unit": "hour",
+                "rate": 0.124,
+                "description": "2 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c2r4-windows",
+                "unit": "hour",
+                "rate": 0.028,
+                "description": "2 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c2r4-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.606,
+                "description": "2 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c2r6",
+                "unit": "hour",
+                "rate": 0.160,
+                "description": "2 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c2r6-windows",
+                "unit": "hour",
+                "rate": 0.036,
+                "description": "2 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c2r6-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.782,
+                "description": "2 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c2r8",
+                "unit": "hour",
+                "rate": 0.196,
+                "description": "2 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c2r8-windows",
+                "unit": "hour",
+                "rate": 0.040,
+                "description": "2 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c2r8-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.958,
+                "description": "2 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c2r16",
+                "unit": "hour",
+                "rate": 0.339,
+                "description": "2 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c2r16-windows",
+                "unit": "hour",
+                "rate": 0.076,
+                "description": "2 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c2r16-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.658,
+                "description": "2 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c4r2",
+                "unit": "hour",
+                "rate": 0.14,
+                "description": "4 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c4r2-windows",
+                "unit": "hour",
+                "rate": 0.031,
+                "description": "4 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c4r2-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.685,
+                "description": "4 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "c1.c4r4",
+                "unit": "hour",
+                "rate": 0.176,
+                "description": "4 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c4r4-windows",
+                "unit": "hour",
+                "rate": 0.039,
+                "description": "4 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c4r4-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.861,
+                "description": "4 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c4r6",
+                "unit": "hour",
+                "rate": 0.212,
+                "description": "4 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c4r6-windows",
+                "unit": "hour",
+                "rate": 0.047,
+                "description": "4 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c4r6-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.037,
+                "description": "4 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c4r8",
+                "unit": "hour",
+                "rate": 0.248,
+                "description": "4 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c4r8-windows",
+                "unit": "hour",
+                "rate": 0.055,
+                "description": "4 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c4r8-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.213,
+                "description": "4 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c4r16",
+                "unit": "hour",
+                "rate": 0.391,
+                "description": "4 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c4r16-windows",
+                "unit": "hour",
+                "rate": 0.087,
+                "description": "4 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c4r16-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.974,
+                "description": "4 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c4r24",
+                "unit": "hour",
+                "rate": 0.535,
+                "description": "4 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c4r24-windows",
+                "unit": "hour",
+                "rate": 0.119,
+                "description": "4 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c4r24-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.332,
+                "description": "4 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c4r32",
+                "unit": "hour",
+                "rate": 0.678,
+                "description": "4 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c4r32-windows",
+                "unit": "hour",
+                "rate": 0.151,
+                "description": "4 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c4r32-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.668,
+                "description": "4 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c8r4",
+                "unit": "hour",
+                "rate": 0.280,
+                "description": "8 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c8r4-windows",
+                "unit": "hour",
+                "rate": 0.062,
+                "description": "8 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c8r4-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.697,
+                "description": "8 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c8r6",
+                "unit": "hour",
+                "rate": 0.316,
+                "description": "8 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c8r6-windows",
+                "unit": "hour",
+                "rate": 0.071,
+                "description": "8 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "c1.c8r6-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.787,
+                "description": "8 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "c1.c8r8",
+                "unit": "hour",
+                "rate": 0.352,
+                "description": "8 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c8r8-windows",
+                "unit": "hour",
+                "rate": 0.079,
+                "description": "8 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c8r8-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 0.876,
+                "description": "8 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c8r16",
+                "unit": "hour",
+                "rate": 0.496,
+                "description": "8 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c8r16-windows",
+                "unit": "hour",
+                "rate": 0.111,
+                "description": "8 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c8r16-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.235,
+                "description": "8 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c8r24",
+                "unit": "hour",
+                "rate": 0.640,
+                "description": "8 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c8r24-windows",
+                "unit": "hour",
+                "rate": 0.143,
+                "description": "8 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c8r16-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.594,
+                "description": "8 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c8r32",
+                "unit": "hour",
+                "rate": 0.783,
+                "description": "8 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c8r32-windows",
+                "unit": "hour",
+                "rate": 0.175,
+                "description": "8 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c8r32-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.950,
+                "description": "8 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c8r64",
+                "unit": "hour",
+                "rate": 1.112,
+                "description": "8 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c8r64-windows",
+                "unit": "hour",
+                "rate": 0.248,
+                "description": "8 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c8r64-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 2.769,
+                "description": "8 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c16r8",
+                "unit": "hour",
+                "rate": 0.566,
+                "description": "16 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c16r8-windows",
+                "unit": "hour",
+                "rate": 0.126,
+                "description": "16 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c16r8-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.409,
+                "description": "16 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "c1.c16r16",
+                "unit": "hour",
+                "rate": 0.711,
+                "description": "16 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c16r16-windows",
+                "unit": "hour",
+                "rate": 0.159,
+                "description": "16 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c16r16-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 1.770,
+                "description": "16 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c16r24",
+                "unit": "hour",
+                "rate": 0.856,
+                "description": "16 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c16r24-windows",
+                "unit": "hour",
+                "rate": 0.191,
+                "description": "16 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c16r24-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 2.131,
+                "description": "16 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c16r32",
+                "unit": "hour",
+                "rate": 1.001,
+                "description": "16 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c16r32-windows",
+                "unit": "hour",
+                "rate": 0.223,
+                "description": "16 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c16r32-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 2.491,
+                "description": "16 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c16r64",
+                "unit": "hour",
+                "rate": 1.352,
+                "description": "16 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c16r64-windows",
+                "unit": "hour",
+                "rate": 0.302,
+                "description": "16 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c16r64-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 3.366,
+                "description": "16 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c16r96",
+                "unit": "hour",
+                "rate": 1.599,
+                "description": "16 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "c1.c16r96-windows",
+                "unit": "hour",
+                "rate": 0.357,
+                "description": "16 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "c1.c16r96-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 3.982,
+                "description": "16 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "c1.c16r128",
+                "unit": "hour",
+                "rate": 1.845,
+                "description": "16 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "c1.c16r128-windows",
+                "unit": "hour",
+                "rate": 0.412,
+                "description": "16 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "c1.c16r128-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 4.594,
+                "description": "16 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "c1.c16r256",
+                "unit": "hour",
+                "rate": 3.176,
+                "description": "16 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c16r256-windows",
+                "unit": "hour",
+                "rate": 0.709,
+                "description": "16 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c16r256-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 7.908,
+                "description": "16 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c32r16",
+                "unit": "hour",
+                "rate": 1.057,
+                "description": "32 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c32r16-windows",
+                "unit": "hour",
+                "rate": 0.236,
+                "description": "32 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c32r16-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 2.632,
+                "description": "32 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "c1.c32r24",
+                "unit": "hour",
+                "rate": 1.159,
+                "description": "32 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c32r24-windows",
+                "unit": "hour",
+                "rate": 0.259,
+                "description": "32 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c32r24-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 2.886,
+                "description": "32 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "c1.c32r32",
+                "unit": "hour",
+                "rate": 1.260,
+                "description": "32 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c32r32-windows",
+                "unit": "hour",
+                "rate": 0.281,
+                "description": "32 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c32r32-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 3.137,
+                "description": "32 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "c1.c32r64",
+                "unit": "hour",
+                "rate": 1.586,
+                "description": "32 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c32r64-windows",
+                "unit": "hour",
+                "rate": 0.354,
+                "description": "32 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c32r64-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 3.949,
+                "description": "32 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "c1.c32r96",
+                "unit": "hour",
+                "rate": 1.816,
+                "description": "32 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "c1.c32r96-windows",
+                "unit": "hour",
+                "rate": 0.405,
+                "description": "32 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "c1.c32r96-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 4.552,
+                "description": "32 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "c1.c32r128",
+                "unit": "hour",
+                "rate": 2.191,
+                "description": "32 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "c1.c32r128-windows",
+                "unit": "hour",
+                "rate": 0.489,
+                "description": "32 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "c1.c32r128-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 5.456,
+                "description": "32 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "c1.c32r256",
+                "unit": "hour",
+                "rate": 3.688,
+                "description": "32 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c32r256-windows",
+                "unit": "hour",
+                "rate": 0.823,
+                "description": "32 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c32r256-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 9.183,
+                "description": "32 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c32r512",
+                "unit": "hour",
+                "rate": 6.352,
+                "description": "32 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "c1.c32r512-windows",
+                "unit": "hour",
+                "rate": 1.418,
+                "description": "32 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "c1.c32r512-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 15.816,
+                "description": "32 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "c1.c64r256",
+                "unit": "hour",
+                "rate": 4.381,
+                "description": "64 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c64r256-windows",
+                "unit": "hour",
+                "rate": 0.978,
+                "description": "64 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c64r256-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 10.909,
+                "description": "64 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "c1.c64r512",
+                "unit": "hour",
+                "rate": 6.916,
+                "description": "64 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "c1.c64r512-windows",
+                "unit": "hour",
+                "rate": 1.544,
+                "description": "64 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "c1.c64r512-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 17.221,
+                "description": "64 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "c1.c64r768",
+                "unit": "hour",
+                "rate": 9.810,
+                "description": "64 vCPU, 768 GB RAM"
+            },
+            {
+                "name": "c1.c64r768-windows",
+                "unit": "hour",
+                "rate": 2.190,
+                "description": "64 vCPU, 768 GB RAM"
+            },
+            {
+                "name": "c1.c64r768-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 24.427,
+                "description": "64 vCPU, 768 GB RAM"
+            },
+            {
+                "name": "c1.c64r1024",
+                "unit": "hour",
+                "rate": 12.703,
+                "description": "64 vCPU, 1024 GB RAM"
+            },
+            {
+                "name": "c1.c64r1024-windows",
+                "unit": "hour",
+                "rate": 2.835,
+                "description": "64 vCPU, 1024 GB RAM"
+            },
+            {
+                "name": "c1.c64r1024-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 31.630,
+                "description": "64 vCPU, 1024 GB RAM"
+            },
+            {
+                "name": "c1.c64r1280",
+                "unit": "hour",
+                "rate": 15.596,
+                "description": "64 vCPU, 1280 GB RAM"
+            },
+            {
+                "name": "c1.c64r1280-windows",
+                "unit": "hour",
+                "rate": 3.481,
+                "description": "64 vCPU, 1280 GB RAM"
+            },
+            {
+                "name": "c1.c64r1280-sql-server-standard-windows",
+                "unit": "hour",
+                "rate": 38.834,
+                "description": "64 vCPU, 1280 GB RAM"
+            }
+        ],
+        "database": [
+            {
+                "name": "db.c1.c1r05",
+                "unit": "hour",
+                "rate": 0.032,
+                "description": "MySQL - 1 vCPU, 0.5 GB RAM"
+            },
+            {
+                "name": "db.c1.c1r1",
+                "unit": "hour",
+                "rate": 0.074,
+                "description": "MySQL - 1 vCPU, 1 GB RAM"
+            },
+            {
+                "name": "db.c1.c1r2",
+                "unit": "hour",
+                "rate": 0.118,
+                "description": "MySQL - 1 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "db.c1.c1r4",
+                "unit": "hour",
+                "rate": 0.187,
+                "description": "MySQL - 1 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "db.c1.c2r1",
+                "unit": "hour",
+                "rate": 0.133,
+                "description": "MySQL - 2 vCPU, 1 GB RAM"
+            },
+            {
+                "name": "db.c1.c2r2",
+                "unit": "hour",
+                "rate": 0.168,
+                "description": "MySQL - 2 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "db.c1.c2r4",
+                "unit": "hour",
+                "rate": 0.236,
+                "description": "MySQL - 2 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "db.c1.c2r6",
+                "unit": "hour",
+                "rate": 0.305,
+                "description": "MySQL - 2 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "db.c1.c2r8",
+                "unit": "hour",
+                "rate": 0.374,
+                "description": "MySQL - 2 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "db.c1.c2r16",
+                "unit": "hour",
+                "rate": 0.646,
+                "description": "MySQL - 2 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "db.c1.c4r2",
+                "unit": "hour",
+                "rate": 0.267,
+                "description": "MySQL - 4 vCPU, 2 GB RAM"
+            },
+            {
+                "name": "db.c1.c4r4",
+                "unit": "hour",
+                "rate": 0.336,
+                "description": "MySQL - 4 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "db.c1.c4r6",
+                "unit": "hour",
+                "rate": 0.404,
+                "description": "MySQL - 4 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "db.c1.c4r8",
+                "unit": "hour",
+                "rate": 0.473,
+                "description": "MySQL - 4 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "db.c1.c4r16",
+                "unit": "hour",
+                "rate": 0.746,
+                "description": "MySQL - 4 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "db.c1.c4r24",
+                "unit": "hour",
+                "rate": 1.020,
+                "description": "MySQL - 4 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "db.c1.c4r32",
+                "unit": "hour",
+                "rate": 1.293,
+                "description": "MySQL - 4 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "db.c1.c8r4",
+                "unit": "hour",
+                "rate": 0.534,
+                "description": "MySQL - 8 vCPU, 4 GB RAM"
+            },
+            {
+                "name": "db.c1.c8r6",
+                "unit": "hour",
+                "rate": 0.603,
+                "description": "MySQL - 8 vCPU, 6 GB RAM"
+            },
+            {
+                "name": "db.c1.c8r8",
+                "unit": "hour",
+                "rate": 0.671,
+                "description": "MySQL - 8 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "db.c1.c8r16",
+                "unit": "hour",
+                "rate": 0.946,
+                "description": "MySQL - 8 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "db.c1.c8r24",
+                "unit": "hour",
+                "rate": 1.220,
+                "description": "MySQL - 8 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "db.c1.c8r32",
+                "unit": "hour",
+                "rate": 1.493,
+                "description": "MySQL - 8 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "db.c1.c8r64",
+                "unit": "hour",
+                "rate": 2.121,
+                "description": "MySQL - 8 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r8",
+                "unit": "hour",
+                "rate": 1.079,
+                "description": "MySQL - 16 vCPU, 8 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r16",
+                "unit": "hour",
+                "rate": 1.356,
+                "description": "MySQL - 16 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r24",
+                "unit": "hour",
+                "rate": 1.632,
+                "description": "MySQL - 16 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r32",
+                "unit": "hour",
+                "rate": 1.909,
+                "description": "MySQL - 16 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r64",
+                "unit": "hour",
+                "rate": 2.578,
+                "description": "MySQL - 16 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r96",
+                "unit": "hour",
+                "rate": 3.518,
+                "description": "MySQL - 16 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r128",
+                "unit": "hour",
+                "rate": 3.518,
+                "description": "MySQL - 16 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "db.c1.c16r256",
+                "unit": "hour",
+                "rate": 6.057,
+                "description": "MySQL - 16 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r16",
+                "unit": "hour",
+                "rate": 2.016,
+                "description": "MySQL - 32 vCPU, 16 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r24",
+                "unit": "hour",
+                "rate": 2.210,
+                "description": "MySQL - 32 vCPU, 24 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r32",
+                "unit": "hour",
+                "rate": 2.403,
+                "description": "MySQL - 32 vCPU, 32 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r64",
+                "unit": "hour",
+                "rate": 3.025,
+                "description": "MySQL - 32 vCPU, 64 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r96",
+                "unit": "hour",
+                "rate": 3.463,
+                "description": "MySQL - 32 vCPU, 96 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r128",
+                "unit": "hour",
+                "rate": 4.178,
+                "description": "MySQL - 32 vCPU, 128 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r256",
+                "unit": "hour",
+                "rate": 7.033,
+                "description": "MySQL - 32 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "db.c1.c32r512",
+                "unit": "hour",
+                "rate": 12.113,
+                "description": "MySQL - 32 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "db.c1.c64r256",
+                "unit": "hour",
+                "rate": 8.355,
+                "description": "MySQL - 64 vCPU, 256 GB RAM"
+            },
+            {
+                "name": "db.c1.c64r512",
+                "unit": "hour",
+                "rate": 13.189,
+                "description": "MySQL - 64 vCPU, 512 GB RAM"
+            },
+            {
+                "name": "db.c1.c64r768",
+                "unit": "hour",
+                "rate": 18.708,
+                "description": "MySQL - 64 vCPU, 768 GB RAM"
+            },
+            {
+                "name": "db.c1.c64r1024",
+                "unit": "hour",
+                "rate": 24.225,
+                "description": "MySQL - 64 vCPU, 1024 GB RAM"
+            },
+            {
+                "name": "db.c1.c64r1280",
+                "unit": "hour",
+                "rate": 29.742,
+                "description": "MySQL - 64 vCPU, 1280 GB RAM"
+            }
+        ],
+        "block_storage": [
+            {
+                "name": "b1.standard",
+                "unit": "gigabyte",
+                "rate": 0.000416,
+                "description": "b1.standard"
+            },
+            {
+                "name": "b1.sr-r2-hdd-100",
+                "unit": "gigabyte",
+                "rate": 0.000248,
+                "description": "b1.sr-r2-hdd-100"
+            },
+            {
+                "name": "b1.sr-r3-hdd-250",
+                "unit": "gigabyte",
+                "rate": 0.000342,
+                "description": "b1.sr-r3-hdd-250"
+            },
+            {
+                "name": "b1.sr-r3-hdd-500",
+                "unit": "gigabyte",
+                "rate": 0.000416,
+                "description": "b1.sr-r3-hdd-500"
+            },
+            {
+                "name": "b1.sr-r3-nvme-1000",
+                "unit": "gigabyte",
+                "rate": 0.000523,
+                "description": "b1.sr-r3-nvme-1000"
+            },
+            {
+                "name": "b1.sr-r3-nvme-2500",
+                "unit": "gigabyte",
+                "rate": 0.000581,
+                "description": "b1.sr-r3-nvme-2500"
+            },
+            {
+                "name": "b1.sr-r3-nvme-5000",
+                "unit": "gigabyte",
+                "rate": 0.000678,
+                "description": "b1.sr-r3-nvme-5000"
+            }
+        ],
+        "object_storage": [
+            {
+                "name": "o1.standard",
+                "unit": "gigabyte",
+                "rate": 0.000275,
+                "description": "Multi-region 3 replicas"
+            },
+            {
+                "name": "{{ region | replace('.', '-') }}--o1--mr-r3",
+                "unit": "gigabyte",
+                "rate": 0.000275,
+                "description": "Multi-region 3 replicas"
+            },
+            {
+                "name": "{{ region | replace('.', '-') }}--o1--sr-r3",
+                "unit": "gigabyte",
+                "rate": 0.000041,
+                "description": "Single region 3 replicas"
+            }
+        ],
+        "network": [
+            {
+                "name": "n1.ipv4",
+                "unit": "hour",
+                "rate": 0.006,
+                "description": "Public IPv4"
+            },
+            {
+                "name": "n1.network",
+                "unit": "hour",
+                "rate": 0.0164,
+                "description": "Network",
+                "first-free": true
+            },
+            {
+                "name": "n1.router",
+                "unit": "hour",
+                "rate": 0.017,
+                "description": "Router",
+                "first-free": true
+            },
+            {
+                "name": "n1.lb",
+                "unit": "hour",
+                "rate": 0.034,
+                "description": "Load balancer"
+            },
+            {
+                "name": "n1.vpn",
+                "unit": "hour",
+                "rate": 0.017,
+                "description": "VPN"
+            }
+        ],
+        "data transfer": [
+            {
+                "name": "n1.local",
+                "unit": "gigabyte",
+                "rate": 0,
+                "description": "Between cloud services in the same region"
+            },
+            {
+                "name": "o1.local",
+                "unit": "gigabyte",
+                "rate": 0,
+                "description": "Between compute instances and object storage in the same region"
+            },
+            {
+                "name": "n1.inter-region",
+                "unit": "gigabyte",
+                "rate": 0.12,
+                "description": "Between cloud services in different regions"
+            },
+            {
+                "name": "n1.national-in",
+                "unit": "gigabyte",
+                "rate": 0,
+                "description": "National data transfer from the internet to the cloud"
+            },
+            {
+                "name": "n1.national-out",
+                "unit": "gigabyte",
+                "rate": 0.12,
+                "description": "National data transfer from the cloud to the internet"
+            },
+            {
+                "name": "n1.international-in",
+                "unit": "gigabyte",
+                "rate": 0,
+                "description": "International data transfer from the internet to the cloud"
+            },
+            {
+                "name": "n1.international-out",
+                "unit": "gigabyte",
+                "rate": 0.3,
+                "description": "International data transfer from the cloud to the internet"
+            }
+        ],
+        "alarms": [
+            {
+                "name": "a1.alarm",
+                "unit": "hour",
+                "rate": 0,
+                "description": "Alarm name."
+            }
+        ],
+        "COE": [
+            {
+                "name": "coe1.cluster",
+                "unit": "hour",
+                "rate": 0.2,
+                "description": "COE Cluster"
+            },
+            {
+                "name": "coe1.worker",
+                "unit": "worker",
+                "rate": 0.05,
+                "description": "COE Worker"
+            }
+        ]
+    }{% if not loop.last %},{% endif +%}
+{% endfor %}
+}

--- a/roles/collector/README.md
+++ b/roles/collector/README.md
@@ -1,0 +1,58 @@
+# `catalystcloud.distil.collector`
+
+An Ansible role for managing Distil Collector.
+
+Distil Collector is the backend service that does the majority of the data processing.
+
+A collection run is performed on startup.
+Jobs are scheduled to perform subsequent collection runs at the same time the next hour, and so on.
+
+First, Keystone is queried for a list of active projects.
+After filtering domains and projects as defined in the configuration,
+the following steps are performed for each defined rated service for each project:
+
+1. Query the telemetry service (currently only Ceilometer API is supported) to discover usage within the next window to be collected for the project.
+1. Transform (rate) the usage according to the meter mapping/transformer configuration.
+1. Create the corresponding usage entries for Distil services within the rated window.
+
+If a project is already up to date on its collection, it is skipped.
+
+By default, a single service container named `distil-collector`,
+that collects all projects and domains, will be created on the host.
+
+Running multiple collectors at once from the same host is also supported,
+with different domain/project filtering options defined for different collector types.
+This is useful for separating collection concerns (e.g. customer projects and internal projects),
+so that if one of the collectors fail or has performance issues, it does not affect others.
+
+Distil Collector also exposes an optional Prometheus exporter called Distil Collector Exporter,
+run as a separate thread within the Distil Collector process, with metrics tracked in-memory.
+This allows for collection of reasonably accurate collection run metrics efficiently,
+without performing expensive database queries. This collector serves HTTP to port 16799 by default.
+
+To scrape this exporter, add a scrape config to your Prometheus instance like so:
+
+```yaml
+---
+
+scrape_configs:
+  - job_name: distil_collector
+    metrics_path: /metrics
+    scheme: http
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets:
+          - 192.0.2.1:16799
+          # Add additional configs for each additional configured collector.
+```
+
+The following metrics are exported:
+
+* `distil_collector_build_info{...}` (`gauge`) - Distil Collector library versions and uptime status
+* `distil_collector_last_run_start` (`gauge`) - Unix timestamp for the latest collection run's start time
+* `distil_collector_last_run_end` (`gauge`) - Unix timestamp for the latest collection run's end time
+* `distil_collector_last_run_duration_seconds` (`gauge`) - Latest collection run's duration, in seconds
+* `distil_collector_usage_total{project_id(str), service(str), unit(str)}` (`counter`) - Total usage under each service for a given project
+
+For more information, check the documentation for the `catalystcloud.distil` collection.

--- a/roles/collector/defaults/main.yml
+++ b/roles/collector/defaults/main.yml
@@ -13,6 +13,10 @@ distil_collector_compose_project_name_base: "distil-collector"
 # Set to null to auto-generate.
 distil_collector_container_name_base: "distil-collector"
 
+# Service-specific SSL settings.
+# By default, use the global Distil values.
+distil_collector_ssl_cacert: "{{ distil_ssl_cacert }}"
+
 # Distil Collector options.
 distil_collector_periodic_interval: 3600  # Collect usage at least once every hour.
 distil_collector_collect_window: 1  # Collect in 1 hour increments (1 hour every window).

--- a/roles/collector/defaults/main.yml
+++ b/roles/collector/defaults/main.yml
@@ -25,4 +25,5 @@ distil_collector_max_collection_start_age: 864  # 864 hours (36 days)
 # Distil Collector Exporter options.
 distil_collector_exporter_enable: true
 distil_collector_exporter_address: "0.0.0.0"
+distil_collector_exporter_port: 16799  # Applies to the default collector only.
 distil_collector_exporter_start_timeout: 300  # seconds

--- a/roles/collector/defaults/main.yml
+++ b/roles/collector/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+
+# Base for constructing the collector base subdirectory paths.
+# Non-default collectors will have '-<collector-name>' appended to the end of the path.
+distil_collector_base_dir_base: "{{ distil_base_dir }}/collector"
+
+# Project name to use when managing service containers via Docker Compose.
+# Non-default collectors will have '-<collector-name>' appended to the end of the name.
+distil_collector_compose_project_name_base: "distil-collector"
+
+# Base container name for the Distil Collector services.
+# Non-default collectors will have '-<collector-name>' appended to the end of the name.
+# Set to null to auto-generate.
+distil_collector_container_name_base: "distil-collector"
+
+# Distil Collector options.
+distil_collector_periodic_interval: 3600  # Collect usage at least once every hour.
+distil_collector_collect_window: 1  # Collect in 1 hour increments (1 hour every window).
+distil_collector_max_windows_per_cycle: 12  # Collect up to 12 windows per collection run.
+distil_collector_trust_sources:
+  - "openstack"
+  - ".{32}:TrafficAccounting"
+distil_collector_max_collection_start_age: 864  # 864 hours (36 days)
+
+# Distil Collector Exporter options.
+distil_collector_exporter_enable: true
+distil_collector_exporter_address: "0.0.0.0"
+distil_collector_exporter_start_timeout: 300  # seconds

--- a/roles/collector/tasks/disable.yml
+++ b/roles/collector/tasks/disable.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Disable Distil Collector
+  ansible.builtin.include_tasks:
+    file: subtasks/disable.yml
+  loop: "{{ distil_collectors }}"
+  loop_control:
+    loop_var: distil_collector
+    label: "{{ distil_collector.name | default(None) }}"

--- a/roles/collector/tasks/enable.yml
+++ b/roles/collector/tasks/enable.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Enable Distil Collector
+  ansible.builtin.include_tasks:
+    file: subtasks/enable.yml
+  loop: "{{ distil_collectors }}"
+  loop_control:
+    loop_var: distil_collector
+    label: "{{ distil_collector.name | default(None) }}"

--- a/roles/collector/tasks/install.yml
+++ b/roles/collector/tasks/install.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Install Distil Collector
+  ansible.builtin.include_tasks:
+    file: subtasks/install.yml
+  loop: "{{ distil_collectors }}"
+  loop_control:
+    loop_var: distil_collector
+    label: "{{ distil_collector.name | default(None) }}"

--- a/roles/collector/tasks/main.yml
+++ b/roles/collector/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Deploy Distil Collector
+  ansible.builtin.include_tasks:
+    file: subtasks/main.yml
+  loop: "{{ distil_collectors }}"
+  loop_control:
+    loop_var: distil_collector
+    label: "{{ distil_collector.name | default(None) }}"

--- a/roles/collector/tasks/postdeploy.yml
+++ b/roles/collector/tasks/postdeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run after completing the deploy here.
+# Examples include cleaning up old service files.

--- a/roles/collector/tasks/predeploy.yml
+++ b/roles/collector/tasks/predeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run before starting the deploy here.
+# Examples include stopping and disabling old services.

--- a/roles/collector/tasks/stop.yml
+++ b/roles/collector/tasks/stop.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Stop Distil Collector
+  ansible.builtin.include_tasks:
+    file: subtasks/stop.yml
+  loop: "{{ distil_collectors }}"
+  loop_control:
+    loop_var: distil_collector
+    label: "{{ distil_collector.name | default(None) }}"

--- a/roles/collector/tasks/subtasks/common.yml
+++ b/roles/collector/tasks/subtasks/common.yml
@@ -7,10 +7,9 @@
     distil_collector_temp_base_dir: "{{ distil_base_dir }}/distil-collector-{{ distil_collector.name }}"
     distil_collector_temp_compose_project_name: "{{ distil_collector_compose_project_name_base }}-{{ distil_collector.name }}"
     distil_collector_temp_container_name: >-
-      {% if distil_collector_container_name_base %}
       {{
         (distil_collector_container_name_base + '-' + distil_collector.name)
-
+        if distil_collector_container_name_base
         else None
       }}
   when: distil_collector.name | default(False)

--- a/roles/collector/tasks/subtasks/common.yml
+++ b/roles/collector/tasks/subtasks/common.yml
@@ -7,12 +7,13 @@
     distil_collector_temp_base_dir: "{{ distil_base_dir }}/distil-collector-{{ distil_collector.name }}"
     distil_collector_temp_compose_project_name: "{{ distil_collector_compose_project_name_base }}-{{ distil_collector.name }}"
     distil_collector_temp_container_name: >-
+      {% if distil_collector_container_name_base %}
       {{
         (distil_collector_container_name_base + '-' + distil_collector.name)
-        if distil_collector_container_name_base
+
         else None
       }}
-  when: distil_collector.name is defined
+  when: distil_collector.name | default(False)
 
 - name: Set Distil Collector variables for the default collector
   ansible.builtin.set_fact:
@@ -21,4 +22,4 @@
     distil_collector_temp_base_dir: "{{ distil_base_dir }}/distil-collector"
     distil_collector_temp_compose_project_name: "{{ distil_collector_compose_project_name_base }}"
     distil_collector_temp_container_name: "{{ distil_collector_container_name_base }}"
-  when: distil_collector.name is not defined
+  when: distil_collector.name | default(True, True)

--- a/roles/collector/tasks/subtasks/common.yml
+++ b/roles/collector/tasks/subtasks/common.yml
@@ -1,0 +1,24 @@
+---
+
+- name: Set Distil Collector variables for non-default collectors
+  ansible.builtin.set_fact:
+    distil_collector_temp_name: "{{ distil_collector.name }}"
+    distil_collector_temp_description: " ({{ distil_collector.name }})"
+    distil_collector_temp_base_dir: "{{ distil_base_dir }}/distil-collector-{{ distil_collector.name }}"
+    distil_collector_temp_compose_project_name: "{{ distil_collector_compose_project_name_base }}-{{ distil_collector.name }}"
+    distil_collector_temp_container_name: >-
+      {{
+        (distil_collector_container_name_base + '-' + distil_collector.name)
+        if distil_collector_container_name_base
+        else None
+      }}
+  when: distil_collector.name is defined
+
+- name: Set Distil Collector variables for the default collector
+  ansible.builtin.set_fact:
+    distil_collector_temp_name: null
+    distil_collector_temp_description: " (default collector)"
+    distil_collector_temp_base_dir: "{{ distil_base_dir }}/distil-collector"
+    distil_collector_temp_compose_project_name: "{{ distil_collector_compose_project_name_base }}"
+    distil_collector_temp_container_name: "{{ distil_collector_container_name_base }}"
+  when: distil_collector.name is not defined

--- a/roles/collector/tasks/subtasks/common.yml
+++ b/roles/collector/tasks/subtasks/common.yml
@@ -4,7 +4,7 @@
   ansible.builtin.set_fact:
     distil_collector_temp_name: "{{ distil_collector.name }}"
     distil_collector_temp_description: " ({{ distil_collector.name }})"
-    distil_collector_temp_base_dir: "{{ distil_base_dir }}/distil-collector-{{ distil_collector.name }}"
+    distil_collector_temp_base_dir: "{{ distil_base_dir }}/collector-{{ distil_collector.name }}"
     distil_collector_temp_compose_project_name: "{{ distil_collector_compose_project_name_base }}-{{ distil_collector.name }}"
     distil_collector_temp_container_name: >-
       {{
@@ -18,7 +18,7 @@
   ansible.builtin.set_fact:
     distil_collector_temp_name: null
     distil_collector_temp_description: " (default collector)"
-    distil_collector_temp_base_dir: "{{ distil_base_dir }}/distil-collector"
+    distil_collector_temp_base_dir: "{{ distil_base_dir }}/collector"
     distil_collector_temp_compose_project_name: "{{ distil_collector_compose_project_name_base }}"
     distil_collector_temp_container_name: "{{ distil_collector_container_name_base }}"
   when: distil_collector.name | default(True, True)

--- a/roles/collector/tasks/subtasks/disable.yml
+++ b/roles/collector/tasks/subtasks/disable.yml
@@ -14,7 +14,6 @@
     project_name: "{{ distil_collector_temp_compose_project_name }}"
     project_src: "{{ distil_collector_temp_base_dir }}"
     state: absent
-    remove_images: false
     remove_volumes: false
     remove_orphans: false
   when: distil_collector_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/collector/tasks/subtasks/disable.yml
+++ b/roles/collector/tasks/subtasks/disable.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Run per-collector common tasks
+  ansible.builtin.include_tasks:
+    file: common.yml
+
+- name: "Check if the service compose file exists{{ distil_collector_temp_description }}"
+  ansible.builtin.stat:
+    path: "{{ distil_collector_temp_base_dir }}/docker-compose.yml"
+  register: distil_collector_temp_dockercompose_yml
+
+- name: "Destroy service containers (if the compose file exists){{ distil_collector_temp_description }}"
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_collector_temp_compose_project_name }}"
+    project_src: "{{ distil_collector_temp_base_dir }}"
+    state: absent
+    remove_images: false
+    remove_volumes: false
+    remove_orphans: false
+  when: distil_collector_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/collector/tasks/subtasks/enable.yml
+++ b/roles/collector/tasks/subtasks/enable.yml
@@ -7,8 +7,9 @@
 - name: Start service containers
   community.docker.docker_compose_v2:
     project_src: "{{ distil_collector_temp_base_dir }}"
+    files:
+      - docker-compose.yml
     state: present
-    pull: "{{ distil_collector_temp_pull | default('missing') }}"
     recreate: "{{ distil_collector_temp_recreate | default('auto') }}"
   when: not ansible_check_mode
 

--- a/roles/collector/tasks/subtasks/enable.yml
+++ b/roles/collector/tasks/subtasks/enable.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Run per-collector common tasks
+  ansible.builtin.include_tasks:
+    file: common.yml
+
+- name: Start service containers
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_collector_temp_compose_project_name }}"
+    project_src: "{{ distil_collector_temp_base_dir }}"
+    state: "{{ distil_collector_temp_state | default('present') }}"
+    pull: "{{ distil_collector_temp_pull | default('missing') }}"
+    recreate: "{{ distil_collector_temp_recreate | default('auto') }}"
+
+- name: Wait until access port is online (if Distil Collector Exporter is enabled)
+  ansible.builtin.wait_for:
+    host: "{{ ansible_default_ipv4.address }}"
+    port: "{{ distil_collector.exporter_port | default(distil_collector_exporter_port) }}"
+    timeout: "{{ distil_collector_exporter_start_timeout }}"
+  when:
+    - distil_collector_exporter_enable
+    - not ansible_check_mode

--- a/roles/collector/tasks/subtasks/enable.yml
+++ b/roles/collector/tasks/subtasks/enable.yml
@@ -11,6 +11,7 @@
     state: "{{ distil_collector_temp_state | default('present') }}"
     pull: "{{ distil_collector_temp_pull | default('missing') }}"
     recreate: "{{ distil_collector_temp_recreate | default('auto') }}"
+  when: not ansible_check_mode
 
 - name: Wait until access port is online (if Distil Collector Exporter is enabled)
   ansible.builtin.wait_for:

--- a/roles/collector/tasks/subtasks/enable.yml
+++ b/roles/collector/tasks/subtasks/enable.yml
@@ -6,7 +6,6 @@
 
 - name: Start service containers
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_collector_temp_compose_project_name }}"
     project_src: "{{ distil_collector_temp_base_dir }}"
     state: "{{ distil_collector_temp_state | default('present') }}"
     pull: "{{ distil_collector_temp_pull | default('missing') }}"

--- a/roles/collector/tasks/subtasks/enable.yml
+++ b/roles/collector/tasks/subtasks/enable.yml
@@ -7,7 +7,7 @@
 - name: Start service containers
   community.docker.docker_compose_v2:
     project_src: "{{ distil_collector_temp_base_dir }}"
-    state: "{{ distil_collector_temp_state | default('present') }}"
+    state: present
     pull: "{{ distil_collector_temp_pull | default('missing') }}"
     recreate: "{{ distil_collector_temp_recreate | default('auto') }}"
   when: not ansible_check_mode

--- a/roles/collector/tasks/subtasks/install.yml
+++ b/roles/collector/tasks/subtasks/install.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Run per-collector common tasks
+  ansible.builtin.include_tasks:
+    file: common.yml
+
+- name: "Create service directory{{ distil_collector_temp_description }}"
+  ansible.builtin.file:
+    path: "{{ distil_collector_temp_base_dir }}"
+    state: directory
+    owner: root
+    group: "{{ distil_docker_group }}"
+    mode: "0770"
+
+- name: "Create service README file{{ distil_collector_temp_description }}"
+  ansible.builtin.template:
+    src: README.md.j2
+    dest: "{{ distil_collector_temp_base_dir }}/README.md"
+    owner: root
+    group: root
+    mode: "0640"
+
+- name: "Create collector configuration file (distil.conf){{ distil_collector_temp_description }}"
+  ansible.builtin.template:
+    src: distil.conf.j2
+    dest: "{{ distil_collector_temp_base_dir }}/distil.conf"
+    owner: root
+    group: "{{ distil_user_group }}"
+    mode: "0640"
+  register: distil_collector_temp_config_file
+
+- name: "Create service compose file{{ distil_collector_temp_description }}"
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ distil_collector_temp_base_dir }}/docker-compose.yml"
+    owner: root
+    group: "{{ distil_user_name }}"
+    mode: "0640"
+
+- name: "Mark service as changed (if mounted files are changed){{ distil_collector_temp_description }}"
+  ansible.builtin.set_fact:
+    distil_collector_temp_changed: "{{ distil_collector_temp_config_file.changed }}"

--- a/roles/collector/tasks/subtasks/install.yml
+++ b/roles/collector/tasks/subtasks/install.yml
@@ -37,6 +37,13 @@
     group: "{{ distil_user_name }}"
     mode: "0640"
 
+- name: "Pull service containers{{ distil_collector_temp_description }}"
+  community.docker.docker_compose_v2_pull:
+    project_src: "{{ distil_collector_temp_base_dir }}"
+    files:
+      - docker-compose.yml
+  when: not ansible_check_mode
+
 - name: "Mark service as changed (if mounted files are changed){{ distil_collector_temp_description }}"
   ansible.builtin.set_fact:
     distil_collector_temp_changed: "{{ distil_collector_temp_config_file.changed }}"

--- a/roles/collector/tasks/subtasks/main.yml
+++ b/roles/collector/tasks/subtasks/main.yml
@@ -8,7 +8,6 @@
   ansible.builtin.include_tasks:
     file: enable.yml
   vars:
-    distil_collector_temp_pull: always
     distil_collector_temp_recreate: >-
       {{
         'always'

--- a/roles/collector/tasks/subtasks/main.yml
+++ b/roles/collector/tasks/subtasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Install Distil Collector
+  ansible.builtin.include_tasks:
+    file: install.yml
+
+- name: Enable Distil Collector
+  ansible.builtin.include_tasks:
+    file: enable.yml
+  vars:
+    distil_collector_temp_pull: always
+    distil_collector_temp_state: >-
+      {{
+        'restarted'
+        if (distil_base_temp_changed | default(False)) or distil_collector_temp_changed
+        else 'present'
+      }}

--- a/roles/collector/tasks/subtasks/main.yml
+++ b/roles/collector/tasks/subtasks/main.yml
@@ -9,9 +9,9 @@
     file: enable.yml
   vars:
     distil_collector_temp_pull: always
-    distil_collector_temp_state: >-
+    distil_collector_temp_recreate: >-
       {{
-        'restarted'
+        'always'
         if (distil_base_temp_changed | default(False)) or distil_collector_temp_changed
-        else 'present'
+        else 'auto'
       }}

--- a/roles/collector/tasks/subtasks/stop.yml
+++ b/roles/collector/tasks/subtasks/stop.yml
@@ -11,7 +11,8 @@
 
 - name: "Stop service containers without destroying them (if the compose file exists){{ distil_collector_temp_description }}"
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_collector_temp_compose_project_name }}"
     project_src: "{{ distil_collector_temp_base_dir }}"
+    files:
+      - docker-compose.yml
     state: stopped
   when: distil_collector_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/collector/tasks/subtasks/stop.yml
+++ b/roles/collector/tasks/subtasks/stop.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Run per-collector common tasks
+  ansible.builtin.include_tasks:
+    file: common.yml
+
+- name: "Check if the service compose file exists{{ distil_collector_temp_description }}"
+  ansible.builtin.stat:
+    path: "{{ distil_collector_temp_base_dir }}/docker-compose.yml"
+  register: distil_collector_temp_dockercompose_yml
+
+- name: "Stop service containers without destroying them (if the compose file exists){{ distil_collector_temp_description }}"
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_collector_temp_compose_project_name }}"
+    project_src: "{{ distil_collector_temp_base_dir }}"
+    state: stopped
+  when: distil_collector_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/collector/tasks/subtasks/uninstall.yml
+++ b/roles/collector/tasks/subtasks/uninstall.yml
@@ -14,7 +14,7 @@
     project_name: "{{ distil_collector_temp_compose_project_name }}"
     project_src: "{{ distil_collector_temp_base_dir }}"
     state: absent
-    remove_images: true
+    remove_images: all
     remove_volumes: true
     remove_orphans: false
   when: distil_collector_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/collector/tasks/subtasks/uninstall.yml
+++ b/roles/collector/tasks/subtasks/uninstall.yml
@@ -11,8 +11,9 @@
 
 - name: "Destroy service containers and remove volumes/images (if the compose file exists){{ distil_collector_temp_description }}"
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_collector_temp_compose_project_name }}"
     project_src: "{{ distil_collector_temp_base_dir }}"
+    files:
+      - docker-compose.yml
     state: absent
     remove_images: all
     remove_volumes: true

--- a/roles/collector/tasks/subtasks/uninstall.yml
+++ b/roles/collector/tasks/subtasks/uninstall.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Run per-collector common tasks
+  ansible.builtin.include_tasks:
+    file: common.yml
+
+- name: "Check if the service compose file exists{{ distil_collector_temp_description }}"
+  ansible.builtin.stat:
+    path: "{{ distil_collector_temp_base_dir }}/docker-compose.yml"
+  register: distil_collector_temp_dockercompose_yml
+
+- name: "Destroy service containers and remove volumes/images (if the compose file exists){{ distil_collector_temp_description }}"
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_collector_temp_compose_project_name }}"
+    project_src: "{{ distil_collector_temp_base_dir }}"
+    state: absent
+    remove_images: true
+    remove_volumes: true
+    remove_orphans: false
+  when: distil_collector_temp_dockercompose_yml.stat.exists | default(False)
+
+- name: "Delete service directory{{ distil_collector_temp_description }}"
+  ansible.builtin.file:
+    path: "{{ distil_collector_temp_base_dir }}"
+    state: absent

--- a/roles/collector/tasks/uninstall.yml
+++ b/roles/collector/tasks/uninstall.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Uninstall Distil Collector
+  ansible.builtin.include_tasks:
+    file: subtasks/uninstall.yml
+  loop: "{{ distil_collectors }}"
+  loop_control:
+    loop_var: distil_collector
+    label: "{{ distil_collector.name | default(None) }}"

--- a/roles/collector/templates/README.md.j2
+++ b/roles/collector/templates/README.md.j2
@@ -1,0 +1,43 @@
+# Distil Collector{{ distil_collector_temp_description }}
+
+All commands should be run from the service directory.
+
+```bash
+cd {{ distil_collector_temp_base_dir }}
+```
+
+## Enable
+
+Run the following command to start the service container (if not already running).
+The container will run automatically on startup.
+
+```bash
+docker compose up -d
+```
+
+## Stop
+
+Run the following command to temporarily stop the service container, if it is running.
+Note that this is only a temporary stop. If the host is rebooted, the container will restart.
+
+```bash
+docker compose stop
+```
+
+## Disable
+
+Run the following command to stop and destroy the service container, so it will not
+start automatically on boot.
+
+```bash
+docker compose down
+```
+
+## Checks
+
+You can use any of the following commands to check service status.
+
+```bash
+docker compose top
+docker compose ps
+```

--- a/roles/collector/templates/distil.conf.j2
+++ b/roles/collector/templates/distil.conf.j2
@@ -1,6 +1,6 @@
 [DEFAULT]
 debug = false
-log_file = /var/log/distil/distil-collector{% if distil_collector_name %}-{{ distil_collector_name }}{% endif %}.log
+log_file = /var/log/distil/distil-collector{% if distil_collector_temp_name %}-{{ distil_collector_temp_name }}{% endif %}.log
 timezone = {{ distil_timezone }}
 
 [collector]
@@ -9,8 +9,8 @@ transformer_file = /etc/distil/transformer.yml
 periodic_interval = {{ distil_collector_periodic_interval }}
 collect_window = {{ distil_collector_collect_window }}
 max_windows_per_cycle = {{ distil_collector_max_windows_per_cycle }}
-{% if distil_collector_name %}
-partitioning_suffix = {{ distil_collector_name }}
+{% if distil_collector_temp_name %}
+partitioning_suffix = {{ distil_collector_temp_name }}
 {% else %}
 # partitioning_suffix =
 {% endif %}

--- a/roles/collector/templates/distil.conf.j2
+++ b/roles/collector/templates/distil.conf.j2
@@ -1,0 +1,49 @@
+[DEFAULT]
+debug = false
+log_file = /var/log/distil/distil-collector{% if distil_collector_name %}-{{ distil_collector_name }}{% endif %}.log
+timezone = {{ distil_timezone }}
+
+[collector]
+meter_mappings_file = /etc/distil/meter_mappings.yml
+transformer_file = /etc/distil/transformer.yml
+periodic_interval = {{ distil_collector_periodic_interval }}
+collect_window = {{ distil_collector_collect_window }}
+max_windows_per_cycle = {{ distil_collector_max_windows_per_cycle }}
+{% if distil_collector_name %}
+partitioning_suffix = {{ distil_collector_name }}
+{% else %}
+# partitioning_suffix =
+{% endif %}
+{% if distil_collector.include_domains | default([]) %}
+include_domains = {{ distil_collector.include_domains | join(", ") }}
+{% endif %}
+{% if distil_collector.ignore_domains | default([]) %}
+ignore_domains = {{ distil_collector.ignore_domains | join(", ") }}
+{% endif %}
+{% if distil_collector.include_projects | default([]) %}
+include_tenants = {{ distil_collector.include_projects | join(", ") }}
+{% endif %}
+{% if distil_collector.ignore_projects | default([]) %}
+ignore_tenants = {{ distil_collector.ignore_projects | join(", ") }}
+{% endif %}
+trust_sources = {{ distil_collector_trust_sources | join(", ") }}
+max_collection_start_age = {{ distil_collector_max_collection_start_age }}
+{% if distil_collector_exporter_enable %}
+enable_exporter = true
+exporter_host = {{ distil_collector_exporter_address }}
+exporter_port = {{ distil_collector.exporter_port | default(16799) }}
+{% endif %}
+
+[database]
+connection = {{ distil_database_connection_url }}
+backend = sqlalchemy
+
+[keystone_authtoken]
+auth_type = password
+auth_url = {{ distil_keystone_auth_url_full }}
+username = {{ distil_keystone_user_name }}
+password = {{ distil_keystone_user_password }}
+project_name = {{ distil_keystone_user_project }}
+user_domain_name = {{ distil_keystone_user_domain }}
+project_domain_name = {{ distil_keystone_user_domain }}
+region_name = {{ distil_openstack_region }}

--- a/roles/collector/templates/distil.conf.j2
+++ b/roles/collector/templates/distil.conf.j2
@@ -28,10 +28,10 @@ ignore_tenants = {{ distil_collector.ignore_projects | join(", ") }}
 {% endif %}
 trust_sources = {{ distil_collector_trust_sources | join(", ") }}
 max_collection_start_age = {{ distil_collector_max_collection_start_age }}
-{% if distil_collector_exporter_enable %}
+{% if distil_collector.exporter_enable | default(distil_collector_exporter_enable) %}
 enable_exporter = true
 exporter_host = {{ distil_collector_exporter_address }}
-exporter_port = {{ distil_collector.exporter_port | default(16799) }}
+exporter_port = {{ distil_collector.exporter_port | default(distil_collector_exporter_port) }}
 {% endif %}
 
 [database]

--- a/roles/collector/templates/docker-compose.yml.j2
+++ b/roles/collector/templates/docker-compose.yml.j2
@@ -33,7 +33,7 @@ services:
         target: /var/log/distil
         read_only: false
       - type: bind
-        source: {{ distil_ssl_cacert }}
+        source: {{ distil_collector_ssl_cacert }}
         target: /opt/distil/ssl/ca.crt
         read_only: true
     environment:

--- a/roles/collector/templates/docker-compose.yml.j2
+++ b/roles/collector/templates/docker-compose.yml.j2
@@ -17,15 +17,15 @@ services:
         target: /etc/distil/distil.conf
         read_only: true
       - type: bind
-        source: /docker/volumes/distil/etc/meter_mappings.yml
+        source: {{ distil_config_dir }}/meter_mappings.yml
         target: /etc/distil/meter_mappings.yml
         read_only: true
       - type: bind
-        source: /docker/volumes/distil/etc/transformer.yml
+        source: {{ distil_config_dir }}/transformer.yml
         target: /etc/distil/transformer.yml
         read_only: true
       - type: bind
-        source: /docker/volumes/distil/lib
+        source: {{ distil_lib_dir }}
         target: /var/lib/distil
         read_only: false
       - type: bind

--- a/roles/collector/templates/docker-compose.yml.j2
+++ b/roles/collector/templates/docker-compose.yml.j2
@@ -1,7 +1,7 @@
 ---
 
 services:
-  {{ distil_collector_temp_container_name | default(('distil-exporter-' + distil_collector_name) if distil_collector_name else 'distil_collector', True) }}:
+  {{ distil_collector_temp_container_name | default(('distil-exporter-' + distil_collector_temp_name) if distil_collector_temp_name else 'distil_collector', True) }}:
 {% if distil_collector_temp_container_name %}
     container_name: {{ distil_collector_temp_container_name }}
 {% endif %}

--- a/roles/collector/templates/docker-compose.yml.j2
+++ b/roles/collector/templates/docker-compose.yml.j2
@@ -1,0 +1,43 @@
+---
+
+services:
+  {{ distil_collector_temp_container_name | default(('distil-exporter-' + distil_collector_name) if distil_collector_name else 'distil_collector', true) }}:
+{% if distil_collector_temp_container_name %}
+    container_name: {{ distil_collector_temp_container_name }}
+{% endif %}
+    image: {{ distil_container_image_uri }}:{{ distil_container_image_tag }}
+    restart: always
+    network_mode: host
+    user: "{{ distil_user_uid }}:{{ distil_user_gid }}"
+    volumes:
+      - type: bind
+        source: {{ distil_collector_temp_base_dir }}/distil.conf
+        target: /etc/distil/distil.conf
+        read_only: true
+      - type: bind
+        source: /docker/volumes/distil/etc/meter_mappings.yml
+        target: /etc/distil/meter_mappings.yml
+        read_only: true
+      - type: bind
+        source: /docker/volumes/distil/etc/transformer.yml
+        target: /etc/distil/transformer.yml
+        read_only: true
+      - type: bind
+        source: /docker/volumes/distil/lib
+        target: /var/lib/distil
+        read_only: false
+      - type: bind
+        source: /var/log/distil
+        target: /var/log/distil
+        read_only: false
+      - type: bind
+        source: {{ distil_ssl_cacert }}
+        target: {{ distil_ssl_cacert }}
+        read_only: true
+    environment:
+      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+    entrypoint:
+      - distil-collector
+    command:
+      - --config-file
+      - /etc/distil/distil.conf

--- a/roles/collector/templates/docker-compose.yml.j2
+++ b/roles/collector/templates/docker-compose.yml.j2
@@ -1,5 +1,7 @@
 ---
 
+name: "{{ distil_collector_temp_compose_project_name }}"
+
 services:
   {{ distil_collector_temp_container_name | default(('distil-exporter-' + distil_collector_temp_name) if distil_collector_temp_name else 'distil_collector', True) }}:
 {% if distil_collector_temp_container_name %}

--- a/roles/collector/templates/docker-compose.yml.j2
+++ b/roles/collector/templates/docker-compose.yml.j2
@@ -34,10 +34,10 @@ services:
         read_only: false
       - type: bind
         source: {{ distil_ssl_cacert }}
-        target: {{ distil_ssl_cacert }}
+        target: /opt/distil/ssl/ca.crt
         read_only: true
     environment:
-      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+      - REQUESTS_CA_BUNDLE=/opt/distil/ssl/ca.crt
     entrypoint:
       - distil-collector
     command:

--- a/roles/collector/templates/docker-compose.yml.j2
+++ b/roles/collector/templates/docker-compose.yml.j2
@@ -1,7 +1,7 @@
 ---
 
 services:
-  {{ distil_collector_temp_container_name | default(('distil-exporter-' + distil_collector_name) if distil_collector_name else 'distil_collector', true) }}:
+  {{ distil_collector_temp_container_name | default(('distil-exporter-' + distil_collector_name) if distil_collector_name else 'distil_collector', True) }}:
 {% if distil_collector_temp_container_name %}
     container_name: {{ distil_collector_temp_container_name }}
 {% endif %}

--- a/roles/common/README.md
+++ b/roles/common/README.md
@@ -1,0 +1,5 @@
+# `catalystcloud.distil.common`
+
+Common role, used by other the other Ansible roles in this collection to supply default inventory variables.
+
+For more information, check the documentation for the `catalystcloud.distil` collection.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -22,7 +22,7 @@ distil_docker_group: "root"
 
 # Logging directory options.
 distil_log_dir: "/var/log/distil"
-distil_log_group: "{{ distil_user_group }}"
+distil_log_dir_group: "{{ distil_user_group }}"
 distil_log_dir_mode: "0750"
 
 # Distil SSL certificate file locations on the host.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -34,7 +34,7 @@ distil_ssl_enable: true
 # The host paths should be overridden to the locations specific to the host in the inventory.
 # distil_ssl_cert: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
 # distil_ssl_key: "/etc/ssl/private/ssl-cert-snakeoil.key"
-# distil_ssl_cacert: "/etc/ssl/certs/ca-certificates.crt"
+distil_ssl_cacert: "/etc/ssl/certs/ca-certificates.crt"
 
 # Operating timezone for the Distil services.
 # Billing itself is always in UTC. This mainly effects logging.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -72,6 +72,8 @@ distil_api_port: 9999
 #  * ignore_projects - List of OpenStack projects to ignore for collection (blacklist).
 #                      Can be combined with include_domains/ignore_domains.
 #                      include_projects takes precedence.
+#  * exporter_enable - Enable Distil Collector Exporter for this collector.
+#                      Default is to use the global value (distil_collector_exporter_enable).
 #  * exporter_port - Distil Collector Exporter port for this collector, if enabled.
 #                    Must be unique for each collector on a host.
 #                    Default is 16799.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -19,6 +19,7 @@ distil_docker_group: "root"
 distil_base_dir: "/opt/distil"
 distil_config_dir: "{{ distil_base_dir }}/etc"
 distil_lib_dir: "{{ distil_base_dir }}/lib"
+distil_log_dir: "/var/log/distil"
 
 # Distil SSL certificate file locations on the host.
 # The host paths should be overridden to the locations specific to the host in the inventory.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -12,14 +12,17 @@ distil_user_group: "distil"
 distil_user_uid: 305
 distil_user_gid: 305
 
-# Group to assign to directories that need to be accessible by users who can use Docker.
-distil_docker_group: "root"
-
 # Base directories created for Distil service files.
 distil_base_dir: "/opt/distil"
 distil_config_dir: "{{ distil_base_dir }}/etc"
 distil_lib_dir: "{{ distil_base_dir }}/lib"
 distil_log_dir: "/var/log/distil"
+
+# Group to assign to directories that need to be accessible by users who can use Docker.
+distil_docker_group: "root"
+
+# Group to assign to the logging directory.
+distil_log_group: "{{ distil_user_group }}"
 
 # Distil SSL certificate file locations on the host.
 # The host paths should be overridden to the locations specific to the host in the inventory.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -76,7 +76,7 @@ distil_api_port: 9999
 #                      Default is to use the global value (distil_collector_exporter_enable).
 #  * exporter_port - Distil Collector Exporter port for this collector, if enabled.
 #                    Must be unique for each collector on a host.
-#                    Default is 16799.
+#                    Default is to use the global value (distil_collector_exporter_port).
 distil_collectors:
   # Default: Create a single collector (the default collector). Collect all domains and projects.
   - name: null

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -25,11 +25,16 @@ distil_log_dir: "/var/log/distil"
 distil_log_dir_group: "{{ distil_user_group }}"
 distil_log_dir_mode: "0750"
 
+# Enable SSL encryption on public facing Distil services.
+# Disabling this makes testing easier.
+# For a production deployment, to facilitate end-to-end encrypted traffic,
+# this should be enabled.
+distil_ssl_enable: true
 # Distil SSL certificate file locations on the host.
 # The host paths should be overridden to the locations specific to the host in the inventory.
-distil_ssl_cert: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
-distil_ssl_key: "/etc/ssl/private/ssl-cert-snakeoil.key"
-distil_ssl_cacert: "/etc/ssl/certs/ca-certificates.crt"
+# distil_ssl_cert: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+# distil_ssl_key: "/etc/ssl/private/ssl-cert-snakeoil.key"
+# distil_ssl_cacert: "/etc/ssl/certs/ca-certificates.crt"
 
 # Operating timezone for the Distil services.
 # Billing itself is always in UTC. This mainly effects logging.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -4,16 +4,21 @@
 distil_container_image_uri: "ghcr.io/catalyst-cloud/distil-docker"
 distil_container_image_tag: "queens"
 
-# UID/GID for the Distil service user and group. Requireds
-# distil_user_uid: 305
-# distil_user_gid: 305
-
 # Names for the Distil service user and group.
 distil_user_name: "distil"
 distil_user_group: "distil"
 
+# UID/GID for the Distil service user and group.
+distil_user_uid: 305
+distil_user_gid: 305
+
 # Group to assign to directories that need to be accessible by users who can use Docker.
 distil_docker_group: "root"
+
+# Base directories created for Distil service files.
+distil_base_dir: "/opt/distil"
+distil_config_dir: "{{ distil_base_dir }}/etc"
+distil_lib_dir: "{{ distil_base_dir }}/lib"
 
 # Distil SSL certificate file locations on the host.
 # The host paths should be overridden to the locations specific to the host in the inventory.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -16,13 +16,15 @@ distil_user_gid: 305
 distil_base_dir: "/opt/distil"
 distil_config_dir: "{{ distil_base_dir }}/etc"
 distil_lib_dir: "{{ distil_base_dir }}/lib"
-distil_log_dir: "/var/log/distil"
 
 # Group to assign to directories that need to be accessible by users who can use Docker.
 distil_docker_group: "root"
 
-# Group to assign to the logging directory.
+# Logging directory options.
+distil_log_dir: "/var/log/distil"
 distil_log_group: "{{ distil_user_group }}"
+distil_log_dir_mode: "0750"
+distil_log_file_mode: "0640"
 
 # Distil SSL certificate file locations on the host.
 # The host paths should be overridden to the locations specific to the host in the inventory.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -24,7 +24,6 @@ distil_docker_group: "root"
 distil_log_dir: "/var/log/distil"
 distil_log_group: "{{ distil_user_group }}"
 distil_log_dir_mode: "0750"
-distil_log_file_mode: "0640"
 
 # Distil SSL certificate file locations on the host.
 # The host paths should be overridden to the locations specific to the host in the inventory.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,89 @@
+---
+
+# Distil container image, common to all services.
+distil_container_image_uri: "ghcr.io/catalyst-cloud/distil-docker"
+distil_container_image_tag: "queens"
+
+# UID/GID for the Distil service user and group. Requireds
+# distil_user_uid: 305
+# distil_user_gid: 305
+
+# Names for the Distil service user and group.
+distil_user_name: "distil"
+distil_user_group: "distil"
+
+# Group to assign to directories that need to be accessible by users who can use Docker.
+distil_docker_group: "root"
+
+# Distil SSL certificate file locations on the host.
+# The host paths should be overridden to the locations specific to the host in the inventory.
+distil_ssl_cert: "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+distil_ssl_key: "/etc/ssl/private/ssl-cert-snakeoil.key"
+distil_ssl_cacert: "/etc/ssl/certs/ca-certificates.crt"
+
+# Operating timezone for the Distil services.
+# Billing itself is always in UTC. This mainly effects logging.
+distil_timezone: "Etc/UTC"
+
+# Distil database settings.
+distil_database_flavor: "mysql"
+distil_database_library: "pymysql"
+distil_database_protocol: "{{ distil_database_flavor }}+{{ distil_database_library }}"
+distil_database_hosts:
+  - "localhost:3306"
+distil_database_username: "distil"
+distil_database_password: "123456"
+distil_database_name: "distil"
+distil_database_connection_url: "{{ distil_database_protocol }}://\
+  {% if distil_database_username is defined %}{{ distil_database_username }}\
+  {% if distil_database_password is defined %}:{{ distil_database_password }}\
+  {% endif %}@{% endif %}\
+  {{ distil_database_hosts | join(',') }}/{{ distil_database_name }}"
+
+# Distil API external hostname, bind address and listening port.
+distil_api_hostname: "localhost"
+distil_api_address: "0.0.0.0"
+distil_api_port: 9999
+
+# Distil Collector settings.
+#
+# The Distil Collectors to create, with per-collector options.
+# When running multiple collectors they all run in parallel, which is useful for
+# e.g. isolating collection of projects, to ensure large projects for internal use
+# do not interfere with collection of customer projects.
+# Available options:
+#  * name - Unique name for the collector. Required.
+#           Set to `null` to not assign a name (default collector).
+#  * include_domains - List of OpenStack domains to collect using this collector (whitelist).
+#  * ignore_domains - List of OpenStack domains to ignore for collection (blacklist).
+#                     include_domains takes precedence.
+#  * include_projects - List of OpenStack projects to collect using this collector (whitelist).
+#                       Can be combined with include_domains/ignore_domains.
+#  * ignore_projects - List of OpenStack projects to ignore for collection (blacklist).
+#                      Can be combined with include_domains/ignore_domains.
+#                      include_projects takes precedence.
+#  * exporter_port - Distil Collector Exporter port for this collector, if enabled.
+#                    Must be unique for each collector on a host.
+#                    Default is 16799.
+distil_collectors:
+  # Default: Create a single collector (the default collector). Collect all domains and projects.
+  - name: null
+
+# Distil Exporter bind address and listening port.
+distil_exporter_address: "0.0.0.0"
+distil_exporter_port: 16798
+
+# Distil OpenStack settings.
+distil_openstack_region: "1.example.com"
+
+# Distil Keystone auth settings.
+distil_keystone_auth_url: "http://api.example.com:5000"
+distil_keystone_auth_version: "v3"
+distil_keystone_auth_url_full: "{{ distil_keystone_auth_url }}/{{ distil_keystone_auth_version }}"
+
+# Distil Keystone user settings.
+distil_keystone_user_name: "distil"
+distil_keystone_user_password: "123456"
+distil_keystone_user_email: "distil@localhost"
+distil_keystone_user_project: "services"
+distil_keystone_user_domain: "Default"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -64,12 +64,12 @@ distil_api_port: 9999
 # Available options:
 #  * name - Unique name for the collector. Required.
 #           Set to `null` to not assign a name (default collector).
-#  * include_domains - List of OpenStack domains to collect using this collector (whitelist).
-#  * ignore_domains - List of OpenStack domains to ignore for collection (blacklist).
+#  * include_domains - List of OpenStack domains to collect using this collector (allowlist).
+#  * ignore_domains - List of OpenStack domains to ignore for collection (blocklist).
 #                     include_domains takes precedence.
-#  * include_projects - List of OpenStack projects to collect using this collector (whitelist).
+#  * include_projects - List of OpenStack projects to collect using this collector (allowlist).
 #                       Can be combined with include_domains/ignore_domains.
-#  * ignore_projects - List of OpenStack projects to ignore for collection (blacklist).
+#  * ignore_projects - List of OpenStack projects to ignore for collection (blocklist).
 #                      Can be combined with include_domains/ignore_domains.
 #                      include_projects takes precedence.
 #  * exporter_enable - Enable Distil Collector Exporter for this collector.

--- a/roles/exporter/README.md
+++ b/roles/exporter/README.md
@@ -1,0 +1,34 @@
+# `catalystcloud.distil.exporter`
+
+An Ansible role for managing Distil Exporter.
+
+Distil Exporter exposes a Prometheus exporter for tracking the collection status of projects.
+This service is optional, but enabled by default.
+
+By default, a service container named `distil-exporter` will be created on the host.
+
+Distil Exporter is run as a WSGI app within [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest),
+serving HTTP to port 16798 by default, with 2 workers and 1 concurrent thread per worker.
+
+To scrape this exporter, add a scrape config to your Prometheus instance like so:
+
+```yaml
+---
+
+scrape_configs:
+  - job_name: distil
+    metrics_path: /metrics
+    scheme: http
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets:
+          - 192.0.2.1:16798
+```
+
+The following metrics are exported:
+
+* `distil_build_info{...}` (`gauge`) - Distil library versions and exporter uptime status
+* `distil_last_collected{project_id(str)}` (`gauge`) - Unix timestamp for age of collection for each project
+
+For more information, check the documentation for the `catalystcloud.distil` collection.

--- a/roles/exporter/defaults/main.yml
+++ b/roles/exporter/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+
+# Base subdirectory for this particular service.
+distil_exporter_base_dir: "{{ distil_base_dir }}/exporter"
+
+# Project name to use when managing service containers via Docker Compose.
+distil_exporter_compose_project_name: "distil-exporter"
+
+# Container name for the Distil Exporter service. Set to null to auto-generate.
+distil_exporter_container_name: "distil-exporter"
+
+# The time to wait for Distil Exporter to open its ports during startup, in seconds.
+distil_exporter_start_timeout: 300
+
+# Distil Exporter bind address and port are in the common role.

--- a/roles/exporter/defaults/main.yml
+++ b/roles/exporter/defaults/main.yml
@@ -12,4 +12,8 @@ distil_exporter_container_name: "distil-exporter"
 # The time to wait for Distil Exporter to open its ports during startup, in seconds.
 distil_exporter_start_timeout: 300
 
+# Service-specific SSL settings.
+# By default, use the global Distil values.
+distil_exporter_ssl_cacert: "{{ distil_ssl_cacert }}"
+
 # Distil Exporter bind address and port are in the common role.

--- a/roles/exporter/files/distil-exporter.wsgi
+++ b/roles/exporter/files/distil-exporter.wsgi
@@ -1,0 +1,3 @@
+from distil.api.metrics.prometheus import make_app
+
+application = make_app(['--config-file', '/etc/distil/distil.conf'])

--- a/roles/exporter/tasks/disable.yml
+++ b/roles/exporter/tasks/disable.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 - name: Check if the service compose file exists
   ansible.builtin.stat:
     path: "{{ distil_exporter_base_dir }}/docker-compose.yml"

--- a/roles/exporter/tasks/disable.yml
+++ b/roles/exporter/tasks/disable.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Check if the service compose file exists
+  ansible.builtin.stat:
+    path: "{{ distil_exporter_base_dir }}/docker-compose.yml"
+  register: distil_exporter_temp_dockercompose_yml
+
+- name: Destroy service containers (if the compose file exists)
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_exporter_compose_project_name }}"
+    project_src: "{{ distil_exporter_base_dir }}"
+    state: absent
+    remove_images: false
+    remove_volumes: false
+    remove_orphans: false
+  when: distil_exporter_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/exporter/tasks/disable.yml
+++ b/roles/exporter/tasks/disable.yml
@@ -14,7 +14,6 @@
     project_name: "{{ distil_exporter_compose_project_name }}"
     project_src: "{{ distil_exporter_base_dir }}"
     state: absent
-    remove_images: false
     remove_volumes: false
     remove_orphans: false
   when: distil_exporter_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/exporter/tasks/enable.yml
+++ b/roles/exporter/tasks/enable.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 - name: Enable Distil Exporter
   ansible.builtin.include_tasks:
     file: subtasks/enable.yml

--- a/roles/exporter/tasks/enable.yml
+++ b/roles/exporter/tasks/enable.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Enable Distil Exporter
+  ansible.builtin.include_tasks:
+    file: subtasks/enable.yml

--- a/roles/exporter/tasks/install.yml
+++ b/roles/exporter/tasks/install.yml
@@ -37,6 +37,13 @@
     group: "{{ distil_user_name }}"
     mode: "0640"
 
+- name: Pull service containers
+  community.docker.docker_compose_v2_pull:
+    project_src: "{{ distil_exporter_base_dir }}"
+    files:
+      - docker-compose.yml
+  when: not ansible_check_mode
+
 - name: Mark service as changed (if mounted files are changed)
   ansible.builtin.set_fact:
     distil_exporter_temp_changed: "{{ distil_exporter_temp_wsgi_file.changed }}"

--- a/roles/exporter/tasks/install.yml
+++ b/roles/exporter/tasks/install.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 - name: Create service directory
   ansible.builtin.file:
     path: "{{ distil_exporter_base_dir }}"

--- a/roles/exporter/tasks/install.yml
+++ b/roles/exporter/tasks/install.yml
@@ -1,0 +1,38 @@
+---
+
+- name: Create service directory
+  ansible.builtin.file:
+    path: "{{ distil_exporter_base_dir }}"
+    state: directory
+    owner: root
+    group: docker
+    mode: "0770"
+
+- name: Create service README file
+  ansible.builtin.template:
+    src: README.md.j2
+    dest: "{{ distil_exporter_base_dir }}/README.md"
+    owner: root
+    group: root
+    mode: "0640"
+
+- name: Create WSGI script file
+  ansible.builtin.copy:
+    src: distil-exporter.wsgi
+    dest: "{{ distil_exporter_base_dir }}/distil-exporter.wsgi"
+    owner: root
+    group: root
+    mode: "0644"
+  register: distil_exporter_temp_wsgi_file
+
+- name: Create service compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ distil_exporter_base_dir }}/docker-compose.yml"
+    owner: root
+    group: "{{ distil_user_name }}"
+    mode: "0640"
+
+- name: Mark service as changed (if mounted files are changed)
+  ansible.builtin.set_fact:
+    distil_exporter_temp_changed: "{{ distil_exporter_temp_wsgi_file.changed }}"

--- a/roles/exporter/tasks/main.yml
+++ b/roles/exporter/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Install Distil Exporter
+  ansible.builtin.include_tasks:
+    file: install.yml
+
+- name: Enable Distil Exporter (restart if mounted files changed, or image updated)
+  ansible.builtin.include_tasks:
+    file: subtasks/enable.yml
+  vars:
+    distil_exporter_temp_pull: always
+    distil_exporter_temp_state: >-
+      {{
+        'restarted'
+        if (distil_base_temp_changed | default(False)) or distil_api_temp_changed
+        else 'present'
+      }}

--- a/roles/exporter/tasks/main.yml
+++ b/roles/exporter/tasks/main.yml
@@ -8,7 +8,6 @@
   ansible.builtin.include_tasks:
     file: subtasks/enable.yml
   vars:
-    distil_exporter_temp_pull: always
     distil_collector_temp_recreate: >-
       {{
         'always'

--- a/roles/exporter/tasks/main.yml
+++ b/roles/exporter/tasks/main.yml
@@ -9,9 +9,9 @@
     file: subtasks/enable.yml
   vars:
     distil_exporter_temp_pull: always
-    distil_exporter_temp_state: >-
+    distil_collector_temp_recreate: >-
       {{
-        'restarted'
+        'always'
         if (distil_base_temp_changed | default(False)) or distil_api_temp_changed
-        else 'present'
+        else 'auto'
       }}

--- a/roles/exporter/tasks/postdeploy.yml
+++ b/roles/exporter/tasks/postdeploy.yml
@@ -1,0 +1,4 @@
+---
+
+# NOTE(callumdickinson): Add tasks to run after completing the deploy here.
+# Examples include cleaning up old service files.

--- a/roles/exporter/tasks/postdeploy.yml
+++ b/roles/exporter/tasks/postdeploy.yml
@@ -1,4 +1,8 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 # NOTE(callumdickinson): Add tasks to run after completing the deploy here.
 # Examples include cleaning up old service files.

--- a/roles/exporter/tasks/predeploy.yml
+++ b/roles/exporter/tasks/predeploy.yml
@@ -1,0 +1,4 @@
+---
+
+# NOTE(callumdickinson): Add tasks to run before starting the deploy here.
+# Examples include stopping and disabling old services.

--- a/roles/exporter/tasks/predeploy.yml
+++ b/roles/exporter/tasks/predeploy.yml
@@ -1,4 +1,8 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 # NOTE(callumdickinson): Add tasks to run before starting the deploy here.
 # Examples include stopping and disabling old services.

--- a/roles/exporter/tasks/stop.yml
+++ b/roles/exporter/tasks/stop.yml
@@ -11,7 +11,8 @@
 
 - name: Stop service containers without destroying them (if the compose file exists)
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_exporter_compose_project_name }}"
     project_src: "{{ distil_exporter_base_dir }}"
+    files:
+      - docker-compose.yml
     state: stopped
   when: distil_exporter_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/exporter/tasks/stop.yml
+++ b/roles/exporter/tasks/stop.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 - name: Check if the service compose file exists
   ansible.builtin.stat:
     path: "{{ distil_exporter_base_dir }}/docker-compose.yml"

--- a/roles/exporter/tasks/stop.yml
+++ b/roles/exporter/tasks/stop.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Check if the service compose file exists
+  ansible.builtin.stat:
+    path: "{{ distil_exporter_base_dir }}/docker-compose.yml"
+  register: distil_exporter_temp_dockercompose_yml
+
+- name: Stop service containers without destroying them (if the compose file exists)
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_exporter_compose_project_name }}"
+    project_src: "{{ distil_exporter_base_dir }}"
+    state: stopped
+  when: distil_exporter_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/exporter/tasks/subtasks/enable.yml
+++ b/roles/exporter/tasks/subtasks/enable.yml
@@ -2,7 +2,6 @@
 
 - name: Start service containers
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_exporter_compose_project_name }}"
     project_src: "{{ distil_exporter_base_dir }}"
     state: "{{ distil_exporter_temp_state | default('present') }}"
     pull: "{{ distil_exporter_temp_pull | default('missing') }}"

--- a/roles/exporter/tasks/subtasks/enable.yml
+++ b/roles/exporter/tasks/subtasks/enable.yml
@@ -7,6 +7,7 @@
     state: "{{ distil_exporter_temp_state | default('present') }}"
     pull: "{{ distil_exporter_temp_pull | default('missing') }}"
     recreate: "{{ distil_exporter_temp_recreate | default('auto') }}"
+  when: not ansible_check_mode
 
 - name: Wait until access port is online
   ansible.builtin.wait_for:

--- a/roles/exporter/tasks/subtasks/enable.yml
+++ b/roles/exporter/tasks/subtasks/enable.yml
@@ -3,7 +3,7 @@
 - name: Start service containers
   community.docker.docker_compose_v2:
     project_src: "{{ distil_exporter_base_dir }}"
-    state: "{{ distil_exporter_temp_state | default('present') }}"
+    state: present
     pull: "{{ distil_exporter_temp_pull | default('missing') }}"
     recreate: "{{ distil_exporter_temp_recreate | default('auto') }}"
   when: not ansible_check_mode

--- a/roles/exporter/tasks/subtasks/enable.yml
+++ b/roles/exporter/tasks/subtasks/enable.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Start service containers
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_exporter_compose_project_name }}"
+    project_src: "{{ distil_exporter_base_dir }}"
+    state: "{{ distil_exporter_temp_state | default('present') }}"
+    pull: "{{ distil_exporter_temp_pull | default('missing') }}"
+    recreate: "{{ distil_exporter_temp_recreate | default('auto') }}"
+
+- name: Wait until access port is online
+  ansible.builtin.wait_for:
+    host: "{{ ansible_default_ipv4.address }}"
+    port: "{{ distil_exporter_port }}"
+    timeout: "{{ distil_exporter_start_timeout }}"
+  when: not ansible_check_mode

--- a/roles/exporter/tasks/subtasks/enable.yml
+++ b/roles/exporter/tasks/subtasks/enable.yml
@@ -3,8 +3,9 @@
 - name: Start service containers
   community.docker.docker_compose_v2:
     project_src: "{{ distil_exporter_base_dir }}"
+    files:
+      - docker-compose.yml
     state: present
-    pull: "{{ distil_exporter_temp_pull | default('missing') }}"
     recreate: "{{ distil_exporter_temp_recreate | default('auto') }}"
   when: not ansible_check_mode
 

--- a/roles/exporter/tasks/uninstall.yml
+++ b/roles/exporter/tasks/uninstall.yml
@@ -14,7 +14,7 @@
     project_name: "{{ distil_exporter_compose_project_name }}"
     project_src: "{{ distil_exporter_base_dir }}"
     state: absent
-    remove_images: true
+    remove_images: all
     remove_volumes: true
     remove_orphans: false
   when: distil_exporter_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/exporter/tasks/uninstall.yml
+++ b/roles/exporter/tasks/uninstall.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 - name: Check if the service compose file exists
   ansible.builtin.stat:
     path: "{{ distil_exporter_base_dir }}/docker-compose.yml"

--- a/roles/exporter/tasks/uninstall.yml
+++ b/roles/exporter/tasks/uninstall.yml
@@ -11,8 +11,9 @@
 
 - name: Destroy service containers and remove volumes/images (if the compose file exists)
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_exporter_compose_project_name }}"
     project_src: "{{ distil_exporter_base_dir }}"
+    files:
+      - docker-compose.yml
     state: absent
     remove_images: all
     remove_volumes: true

--- a/roles/exporter/tasks/uninstall.yml
+++ b/roles/exporter/tasks/uninstall.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Check if the service compose file exists
+  ansible.builtin.stat:
+    path: "{{ distil_exporter_base_dir }}/docker-compose.yml"
+  register: distil_exporter_temp_dockercompose_yml
+
+- name: Destroy service containers and remove volumes/images (if the compose file exists)
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_exporter_compose_project_name }}"
+    project_src: "{{ distil_exporter_base_dir }}"
+    state: absent
+    remove_images: true
+    remove_volumes: true
+    remove_orphans: false
+  when: distil_exporter_temp_dockercompose_yml.stat.exists | default(False)
+
+- name: Delete service directory
+  ansible.builtin.file:
+    path: "{{ distil_exporter_base_dir }}"
+    state: absent

--- a/roles/exporter/templates/README.md.j2
+++ b/roles/exporter/templates/README.md.j2
@@ -1,0 +1,43 @@
+# Distil Exporter
+
+All commands should be run from the service directory.
+
+```bash
+cd {{ distil_exporter_base_dir }}
+```
+
+## Enable
+
+Run the following command to start the service container (if not already running).
+The container will run automatically on startup.
+
+```bash
+docker compose up -d
+```
+
+## Stop
+
+Run the following command to temporarily stop the service container, if it is running.
+Note that this is only a temporary stop. If the host is rebooted, the container will restart.
+
+```bash
+docker compose stop
+```
+
+## Disable
+
+Run the following command to stop and destroy the service container, so it will not
+start automatically on boot.
+
+```bash
+docker compose down
+```
+
+## Checks
+
+You can use any of the following commands to check service status.
+
+```bash
+docker compose top
+docker compose ps
+```

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -1,7 +1,7 @@
 ---
 
 services:
-  {{ distil_exporter_container_name | default('distil-exporter', true) }}:
+  {{ distil_exporter_container_name | default('distil-exporter', True) }}:
 {% if distil_exporter_container_name %}
     container_name: {{ distil_exporter_container_name }}
 {% endif %}

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -1,5 +1,7 @@
 ---
 
+name: "{{ distil_exporter_compose_project_name }}"
+
 services:
   {{ distil_exporter_container_name | default('distil-exporter', True) }}:
 {% if distil_exporter_container_name %}

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -25,7 +25,7 @@ services:
         target: /var/log/distil
         read_only: false
       - type: bind
-        source: {{ distil_ssl_cacert }}
+        source: {{ distil_exporter_ssl_cacert }}
         target: /opt/distil/ssl/ca.crt
         read_only: true
       - type: bind

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -26,14 +26,14 @@ services:
         read_only: false
       - type: bind
         source: {{ distil_ssl_cacert }}
-        target: {{ distil_ssl_cacert }}
+        target: /opt/distil/ssl/ca.crt
         read_only: true
       - type: bind
         source: {{ distil_exporter_base_dir }}/distil-exporter.wsgi
-        target: /opt/distil/distil-exporter.wsgi
+        target: /opt/distil/wsgi/distil-exporter
         read_only: true
     environment:
-      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+      - REQUESTS_CA_BUNDLE=/opt/distil/ssl/ca.crt
       - UWSGI_WSGI_ENV_BEHAVIOR=holy
       - UWSGI_HTTP={{ distil_exporter_address }}:{{ distil_exporter_port }}
       - UWSGI_HTTP_AUTO_CHUNKED=1
@@ -50,4 +50,4 @@ services:
     entrypoint:
       - uwsgi
     command:
-      - --wsgi-file=/opt/distil/distil-exporter.wsgi
+      - --wsgi-file=/opt/distil/wsgi/distil-exporter

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -39,7 +39,7 @@ services:
       - UWSGI_WORKERS=2
       - UWSGI_THREADS=1
       - UWSGI_LOGTO={{ distil_log_dir }}/distil-exporter-wsgi.log
-      - UWSGI_LOGFILE_CHMOD={{ distil_log_file_mode }}
+      - UWSGI_LOGFILE_CHMOD=644
       - UWSGI_DIE_ON_TERM=true
       - UWSGI_SHOW_CONFIG=true
       - UWSGI_MASTER=true

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -39,7 +39,7 @@ services:
       - UWSGI_WORKERS=2
       - UWSGI_THREADS=1
       - UWSGI_LOGTO={{ distil_log_dir }}/distil-exporter-wsgi.log
-      - UWSGI_LOGFILE_CHMOD=644
+      - UWSGI_LOGFILE_CHMOD={{ distil_log_file_mode }}
       - UWSGI_DIE_ON_TERM=true
       - UWSGI_SHOW_CONFIG=true
       - UWSGI_MASTER=true

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -1,0 +1,51 @@
+---
+
+services:
+  {{ distil_exporter_container_name | default('distil-exporter', true) }}:
+{% if distil_exporter_container_name %}
+    container_name: {{ distil_exporter_container_name }}
+{% endif %}
+    image: {{ distil_container_image_uri }}:{{ distil_container_image_tag }}
+    restart: always
+    network_mode: host
+    user: "{{ distil_user_uid }}:{{ distil_user_gid }}"
+    volumes:
+      - type: bind
+        source: {{ distil_etc_dir }}
+        target: /etc/distil
+        read_only: true
+      - type: bind
+        source: {{ distil_lib_dir }}
+        target: /var/lib/distil
+        read_only: false
+      - type: bind
+        source: {{ distil_log_dir }}
+        target: /var/log/distil
+        read_only: false
+      - type: bind
+        source: {{ distil_ssl_cacert }}
+        target: {{ distil_ssl_cacert }}
+        read_only: true
+      - type: bind
+        source: {{ distil_exporter_base_dir }}/distil-exporter.wsgi
+        target: /opt/distil/distil-exporter.wsgi
+        read_only: true
+    environment:
+      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+      - UWSGI_WSGI_ENV_BEHAVIOR=holy
+      - UWSGI_HTTP={{ distil_exporter_address }}:{{ distil_exporter_port }}
+      - UWSGI_HTTP_AUTO_CHUNKED=1
+      - UWSGI_HTTP_KEEPALIVE=1
+      - UWSGI_WORKERS=2
+      - UWSGI_THREADS=1
+      - UWSGI_LOGTO={{ distil_log_dir }}/distil-exporter-wsgi.log
+      - UWSGI_LOGFILE_CHMOD=644
+      - UWSGI_DIE_ON_TERM=true
+      - UWSGI_SHOW_CONFIG=true
+      - UWSGI_MASTER=true
+      - UWSGI_MAX_REQUESTS=1000
+      - UWSGI_HARAKIRI=10
+    entrypoint:
+      - uwsgi
+    command:
+      - --wsgi-file=/opt/distil/distil-exporter.wsgi

--- a/roles/exporter/templates/docker-compose.yml.j2
+++ b/roles/exporter/templates/docker-compose.yml.j2
@@ -11,7 +11,7 @@ services:
     user: "{{ distil_user_uid }}:{{ distil_user_gid }}"
     volumes:
       - type: bind
-        source: {{ distil_etc_dir }}
+        source: {{ distil_config_dir }}
         target: /etc/distil
         read_only: true
       - type: bind

--- a/roles/keystone/defaults/main.yml
+++ b/roles/keystone/defaults/main.yml
@@ -1,0 +1,34 @@
+---
+
+# Distil Keystone user configuration is managed by the common role.
+
+distil_keystone_user_roles:
+  - "admin"
+  - "ResellerAdmin"
+
+distil_keystone_role_create:
+  - "ResellerAdmin"
+
+distil_keystone_service_name: "distilv2"
+distil_keystone_service_description: "Distil Rating Service"
+distil_keystone_service_type: "ratingv2"
+distil_keystone_service_interfaces:
+  - "admin"
+  - "internal"
+  - "public"
+
+distil_keystone_endpoint_url: "https://{{ distil_api_hostname }}:{{ distil_api_port }}"
+
+# When requiring explicit Keystone password auth, set the following variable.
+# To ignore OpenStack environment variables from other clouds, set load_envvars to false.
+# distil_keystone_ansible_auth_cloud:
+#   auth_type: "password"
+#   auth:
+#     auth_url: "https://api.example.com:5000/v3"
+#     username: "admin"
+#     password: "123456"
+#     project_name: "openstack"
+#     user_domain_name: "Default"
+#     project_domain_name: "Default"
+#   verify: false
+#   load_envvars: false

--- a/roles/keystone/tasks/authenticate.yml
+++ b/roles/keystone/tasks/authenticate.yml
@@ -1,0 +1,27 @@
+---
+
+# NOTE(callumdickinson): Fetching a token is not strictly required,
+# but it does speed up the average request (by ~1s) compared to using password auth each time.
+- name: Fetch auth token from Keystone (if password auth is configured)
+  run_once: true
+  when:
+    - not ansible_check_mode  # Do not use dynamic auth token in check mode.
+    - distil_keystone_ansible_auth_cloud | default({})
+    - "(distil_keystone_ansible_auth_cloud.auth_type | default('password')) != 'token'"
+  block:
+    # NOTE(dalees): Purposefully not using `auth`, `auth_token`, `validate_certs`
+    # so we can set load_envvars to false.
+    - name: Authenticate with Keystone to fetch auth token
+      openstack.cloud.auth:
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
+    - name: Save Keystone auth token
+      ansible.builtin.set_fact:
+        distil_keystone_ansible_auth_cloud:
+          auth_type: "token"
+          auth:
+            auth_url: "{{ distil_keystone_ansible_auth_cloud.auth.auth_url }}"
+            auth_token: "{{ auth_token }}"
+          verify: "{{ distil_keystone_ansible_auth_cloud.verify | default(omit) }}"
+          # NOTE(dalees): load_envvars is "undocumented magic" but is *required*
+          # if there are `OS_` environment vars set for another cloud.
+          load_envvars: false

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Authenticate with Keystone
+  ansible.builtin.include_tasks: authenticate.yml
+
+- name: Install Keystone user and service
+  run_once: true
+  block:
+    - name: Create Keystone user
+      openstack.cloud.identity_user:
+        name: "{{ distil_keystone_user_name }}"
+        password: "{{ distil_keystone_user_password }}"
+        email: "{{ distil_keystone_user_email }}"
+        default_project: "{{ distil_keystone_user_project }}"
+        domain: "{{ distil_keystone_user_domain }}"
+        enabled: true
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
+    - name: Create Keystone roles
+      openstack.cloud.identity_role:
+        name: "{{ item }}"
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
+      loop: "{{ distil_keystone_role_create }}"
+    - name: Assign roles to Keystone user
+      openstack.cloud.role_assignment:
+        user: "{{ distil_keystone_user_name }}"
+        role: "{{ item }}"
+        project: "{{ distil_keystone_user_project }}"
+        domain: "{{ distil_keystone_user_domain }}"
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
+      loop: "{{ distil_keystone_user_roles }}"
+    - name: Create Keystone catalog service
+      openstack.cloud.catalog_service:
+        name: "{{ distil_keystone_service_name }}"
+        description: "{{ distil_keystone_service_description }}"
+        type: "{{ distil_keystone_service_type }}"
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
+    - name: Create Keystone catalog service endpoints
+      openstack.cloud.endpoint:
+        service: "{{ distil_keystone_service_name }}"
+        region: "{{ distil_openstack_region }}"
+        url: "{{ distil_keystone_endpoint_url }}"
+        endpoint_interface: "{{ item }}"
+        enabled: true
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
+      loop: "{{ distil_keystone_service_interfaces }}"

--- a/roles/keystone/tasks/postdeploy.yml
+++ b/roles/keystone/tasks/postdeploy.yml
@@ -1,0 +1,4 @@
+---
+
+# NOTE(callumdickinson): Add tasks to run after completing the deploy here.
+# Examples include cleaning up old service files.

--- a/roles/keystone/tasks/postdeploy.yml
+++ b/roles/keystone/tasks/postdeploy.yml
@@ -1,4 +1,8 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 # NOTE(callumdickinson): Add tasks to run after completing the deploy here.
 # Examples include cleaning up old service files.

--- a/roles/keystone/tasks/predeploy.yml
+++ b/roles/keystone/tasks/predeploy.yml
@@ -1,0 +1,4 @@
+---
+
+# NOTE(callumdickinson): Add tasks to run before starting the deploy here.
+# Examples include stopping and disabling old services.

--- a/roles/keystone/tasks/predeploy.yml
+++ b/roles/keystone/tasks/predeploy.yml
@@ -1,4 +1,8 @@
 ---
 
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
 # NOTE(callumdickinson): Add tasks to run before starting the deploy here.
 # Examples include stopping and disabling old services.

--- a/roles/keystone/tasks/uninstall.yml
+++ b/roles/keystone/tasks/uninstall.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Authenticate with Keystone
+  ansible.builtin.include_tasks: authenticate.yml
+
+- name: Uninstall Keystone user and service
+  run_once: true
+  block:
+    - name: Delete Keystone catalog service
+      openstack.cloud.catalog_service:
+        name: "{{ distil_keystone_service_name }}"
+        state: absent
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
+    - name: Delete Keystone user
+      openstack.cloud.identity_user:
+        name: "{{ distil_keystone_user_name }}"
+        state: absent
+        cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"

--- a/roles/keystone/tasks/uninstall.yml
+++ b/roles/keystone/tasks/uninstall.yml
@@ -13,6 +13,7 @@
     - name: Delete Keystone catalog service
       openstack.cloud.catalog_service:
         name: "{{ distil_keystone_service_name }}"
+        type: "{{ distil_keystone_service_type }}"
         state: absent
         cloud: "{{ distil_keystone_ansible_auth_cloud | default(omit) }}"
     - name: Delete Keystone user

--- a/roles/manage/README.md
+++ b/roles/manage/README.md
@@ -1,0 +1,10 @@
+# `catalystcloud.distil.manage`
+
+An Ansible role for managing Distil Manage,
+a set of service containers used for administration of Distil.
+
+Currently the only available container is `distil-db-manage`, which is used primarily
+to initialise the Distil database on new installations, and database migrations
+when performing service upgrades.
+
+For more information, check the documentation for the `catalystcloud.distil` collection.

--- a/roles/manage/defaults/main.yml
+++ b/roles/manage/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+
+# Base subdirectory for this particular service.
+distil_manage_base_dir: "{{ distil_base_dir }}/manage"
+
+# Project name to use when managing service containers via Docker Compose.
+distil_manage_compose_project_name: "distil-manage"
+
+# Container name for the Distil DB Manage service. Set to null to auto-generate.
+distil_db_manage_container_name: "distil-db-manage"

--- a/roles/manage/defaults/main.yml
+++ b/roles/manage/defaults/main.yml
@@ -8,3 +8,7 @@ distil_manage_compose_project_name: "distil-manage"
 
 # Container name for the Distil DB Manage service. Set to null to auto-generate.
 distil_db_manage_container_name: "distil-db-manage"
+
+# Service-specific SSL settings.
+# By default, use the global Distil values.
+distil_manage_ssl_cacert: "{{ distil_ssl_cacert }}"

--- a/roles/manage/tasks/install.yml
+++ b/roles/manage/tasks/install.yml
@@ -27,3 +27,10 @@
     owner: root
     group: "{{ distil_user_name }}"
     mode: "0640"
+
+- name: Pull service containers
+  community.docker.docker_compose_v2_pull:
+    project_src: "{{ distil_manage_base_dir }}"
+    files:
+      - docker-compose.yml
+  when: not ansible_check_mode

--- a/roles/manage/tasks/install.yml
+++ b/roles/manage/tasks/install.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Create service directory
+  ansible.builtin.file:
+    path: "{{ distil_manage_base_dir }}"
+    state: directory
+    owner: root
+    group: docker
+    mode: "0770"
+
+- name: Create service README file
+  ansible.builtin.template:
+    src: README.md.j2
+    dest: "{{ distil_manage_base_dir }}/README.md"
+    owner: root
+    group: root
+    mode: "0640"
+
+- name: Create service compose file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ distil_manage_base_dir }}/docker-compose.yml"
+    owner: root
+    group: "{{ distil_user_name }}"
+    mode: "0640"

--- a/roles/manage/tasks/main.yml
+++ b/roles/manage/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Install Distil Manage
+  ansible.builtin.include_tasks:
+    file: install.yml

--- a/roles/manage/tasks/migrate.yml
+++ b/roles/manage/tasks/migrate.yml
@@ -10,4 +10,5 @@
     chdir: "{{ distil_manage_base_dir }}"
   register: distil_temp_db_manage
   changed_when: "'Running upgrade' in distil_temp_db_manage.stderr"
+  when: not ansible_check_mode
   run_once: true

--- a/roles/manage/tasks/migrate.yml
+++ b/roles/manage/tasks/migrate.yml
@@ -6,7 +6,14 @@
 
 - name: Migrate Distil database
   ansible.builtin.command:
-    cmd: docker compose --file docker-compose.yml run --rm distil-db-manage
+    argv:
+      - docker
+      - compose
+      - --file
+      - docker-compose.yml
+      - run
+      - --rm
+      - "{{ distil_db_manage_container_name | default('distil-db-manage', True) }}"
     chdir: "{{ distil_manage_base_dir }}"
   register: distil_temp_db_manage
   changed_when: "'Running upgrade' in distil_temp_db_manage.stderr"

--- a/roles/manage/tasks/migrate.yml
+++ b/roles/manage/tasks/migrate.yml
@@ -6,7 +6,7 @@
 
 - name: Migrate Distil database
   ansible.builtin.command:
-    cmd: docker compose --file docker-ompose.yml run --rm distil-db-manage
+    cmd: docker compose --file docker-compose.yml run --rm distil-db-manage
     chdir: "{{ distil_manage_base_dir }}"
   register: distil_temp_db_manage
   changed_when: "'Running upgrade' in distil_temp_db_manage.stderr"

--- a/roles/manage/tasks/migrate.yml
+++ b/roles/manage/tasks/migrate.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Migrate Distil database
+  ansible.builtin.command:
+    cmd: docker compose --file docker-ompose.yml run --rm distil-db-manage
+    chdir: "{{ distil_manage_base_dir }}"
+  register: distil_temp_db_manage
+  changed_when: "'Running upgrade' in distil_temp_db_manage.stderr"
+  run_once: true

--- a/roles/manage/tasks/postdeploy.yml
+++ b/roles/manage/tasks/postdeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run after completing the deploy here.
+# Examples include cleaning up old service files.

--- a/roles/manage/tasks/predeploy.yml
+++ b/roles/manage/tasks/predeploy.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+# NOTE(callumdickinson): Add tasks to run before starting the deploy here.
+# Examples include stopping and disabling old services.

--- a/roles/manage/tasks/uninstall.yml
+++ b/roles/manage/tasks/uninstall.yml
@@ -14,7 +14,7 @@
     project_name: "{{ distil_manage_compose_project_name }}"
     project_src: "{{ distil_manage_base_dir }}"
     state: absent
-    remove_images: true
+    remove_images: all
     remove_volumes: true
     remove_orphans: false
   when: distil_manage_temp_dockercompose_yml.stat.exists | default(False)

--- a/roles/manage/tasks/uninstall.yml
+++ b/roles/manage/tasks/uninstall.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Import common variables
+  ansible.builtin.import_role:
+    name: common
+
+- name: Check if the service compose file exists
+  ansible.builtin.stat:
+    path: "{{ distil_manage_base_dir }}/docker-compose.yml"
+  register: distil_manage_temp_dockercompose_yml
+
+- name: Destroy service containers and remove volumes/images (if the compose file exists)
+  community.docker.docker_compose_v2:
+    project_name: "{{ distil_manage_compose_project_name }}"
+    project_src: "{{ distil_manage_base_dir }}"
+    state: absent
+    remove_images: true
+    remove_volumes: true
+    remove_orphans: false
+  when: distil_manage_temp_dockercompose_yml.stat.exists | default(False)
+
+- name: Delete service directory
+  ansible.builtin.file:
+    path: "{{ distil_manage_base_dir }}"
+    state: absent

--- a/roles/manage/tasks/uninstall.yml
+++ b/roles/manage/tasks/uninstall.yml
@@ -11,8 +11,9 @@
 
 - name: Destroy service containers and remove volumes/images (if the compose file exists)
   community.docker.docker_compose_v2:
-    project_name: "{{ distil_manage_compose_project_name }}"
     project_src: "{{ distil_manage_base_dir }}"
+    files:
+      - docker-compose.yml
     state: absent
     remove_images: all
     remove_volumes: true

--- a/roles/manage/templates/README.md.j2
+++ b/roles/manage/templates/README.md.j2
@@ -11,7 +11,7 @@ cd {{ distil_api_base_dir }}
 Run the following command to perform a migration on the Distil database.
 
 ```bash
-docker compose run --rm {{ distil_db_manage_container_name | default('distil-db-manage', true) }}
+docker compose run --rm {{ distil_db_manage_container_name | default('distil-db-manage', True) }}
 ```
 
 Logs will be recorded to `{{ distil_log_dir }}/distil-db-manage.log`.

--- a/roles/manage/templates/README.md.j2
+++ b/roles/manage/templates/README.md.j2
@@ -1,0 +1,17 @@
+# Distil API
+
+All commands should be run from the service directory.
+
+```bash
+cd {{ distil_api_base_dir }}
+```
+
+## Database Migration
+
+Run the following command to perform a migration on the Distil database.
+
+```bash
+docker compose run --rm {{ distil_db_manage_container_name | default('distil-db-manage', true) }}
+```
+
+Logs will be recorded to `{{ distil_log_dir }}/distil-db-manage.log`.

--- a/roles/manage/templates/README.md.j2
+++ b/roles/manage/templates/README.md.j2
@@ -3,7 +3,7 @@
 All commands should be run from the service directory.
 
 ```bash
-cd {{ distil_api_base_dir }}
+cd {{ distil_manage_base_dir }}
 ```
 
 ## Database Migration

--- a/roles/manage/templates/docker-compose.yml.j2
+++ b/roles/manage/templates/docker-compose.yml.j2
@@ -1,5 +1,7 @@
 ---
 
+name: "{{ distil_manage_compose_project_name }}"
+
 services:
   {{ distil_db_manage_container_name | default('distil-db-manage', True) }}:
 {% if distil_db_manage_container_name %}

--- a/roles/manage/templates/docker-compose.yml.j2
+++ b/roles/manage/templates/docker-compose.yml.j2
@@ -10,7 +10,7 @@ services:
     user: "{{ distil_user_uid }}"
     volumes:
       - type: bind
-        source: {{ distil_etc_dir }}
+        source: {{ distil_config_dir }}
         target: /etc/distil
         read_only: true
       - type: bind

--- a/roles/manage/templates/docker-compose.yml.j2
+++ b/roles/manage/templates/docker-compose.yml.j2
@@ -1,7 +1,7 @@
 ---
 
 services:
-  {{ distil_db_manage_container_name | default('distil-db-manage', true) }}:
+  {{ distil_db_manage_container_name | default('distil-db-manage', True) }}:
 {% if distil_db_manage_container_name %}
     container_name: {{ distil_db_manage_container_name }}
 {% endif %}

--- a/roles/manage/templates/docker-compose.yml.j2
+++ b/roles/manage/templates/docker-compose.yml.j2
@@ -7,7 +7,7 @@ services:
 {% endif %}
     image: {{ distil_container_image_uri }}:{{ distil_container_image_tag }}
     network_mode: host
-    user: "{{ distil_user_uid }}"
+    user: "{{ distil_user_uid }}:{{ distil_user_gid }}"
     volumes:
       - type: bind
         source: {{ distil_config_dir }}

--- a/roles/manage/templates/docker-compose.yml.j2
+++ b/roles/manage/templates/docker-compose.yml.j2
@@ -24,7 +24,7 @@ services:
         target: /var/log/distil
         read_only: false
       - type: bind
-        source: {{ distil_ssl_cacert }}
+        source: {{ distil_manage_ssl_cacert }}
         target: /opt/distil/ssl/ca.crt
         read_only: true
     environment:

--- a/roles/manage/templates/docker-compose.yml.j2
+++ b/roles/manage/templates/docker-compose.yml.j2
@@ -1,0 +1,36 @@
+---
+
+services:
+  {{ distil_db_manage_container_name | default('distil-db-manage', true) }}:
+{% if distil_db_manage_container_name %}
+    container_name: {{ distil_db_manage_container_name }}
+{% endif %}
+    image: {{ distil_container_image_uri }}:{{ distil_container_image_tag }}
+    network_mode: host
+    user: "{{ distil_user_uid }}"
+    volumes:
+      - type: bind
+        source: {{ distil_etc_dir }}
+        target: /etc/distil
+        read_only: true
+      - type: bind
+        source: {{ distil_lib_dir }}
+        target: /var/lib/distil
+        read_only: false
+      - type: bind
+        source: {{ distil_log_dir }}
+        target: /var/log/distil
+        read_only: false
+      - type: bind
+        source: {{ distil_ssl_cacert }}
+        target: {{ distil_ssl_cacert }}
+        read_only: true
+    environment:
+      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+    entrypoint:
+      - distil-db-manage
+    command:
+      - --config-file
+      - /etc/distil/distil.conf
+      - upgrade
+      - head

--- a/roles/manage/templates/docker-compose.yml.j2
+++ b/roles/manage/templates/docker-compose.yml.j2
@@ -25,10 +25,10 @@ services:
         read_only: false
       - type: bind
         source: {{ distil_ssl_cacert }}
-        target: {{ distil_ssl_cacert }}
+        target: /opt/distil/ssl/ca.crt
         read_only: true
     environment:
-      - REQUESTS_CA_BUNDLE={{ distil_ssl_cacert }}
+      - REQUESTS_CA_BUNDLE=/opt/distil/ssl/ca.crt
     entrypoint:
       - distil-db-manage
     command:


### PR DESCRIPTION
This is an Ansible collection for deploying and managing Distil, a rating service for OpenStack.

For more information on how to use it, refer to the `README` file.

This is the initial version being released to GitHub, and tagged as `1.0.0`. If this starts getting usage by people as-is, I'd also like to upload it to Ansible Galaxy.