### PR TITLE
Add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install pipeline Python packages
+        run: python -m pip install -r requirements.txt
+        env:
+          FORCE_COLOR: "1"
+      - name: Build collection
+        run: ansible-galaxy collection build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: catalystcloud-distil-${{ github.ref_name }}.tar.gz
+          retention-days: 5
+
+  github:
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install Python packages
+        run: python -m pip install -r requirements.txt
+        env:
+          FORCE_COLOR: "1"
+      - name: Generate release notes
+        run: antsibull-changelog generate ${{ github.ref_name }} --only-latest --output-format md --output RELEASENOTES.md
+      - name: Publish the GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: RELEASENOTES.md
+          files: catalystcloud-distil-${{ github.ref_name }}.tar.gz
+          fail_on_unmatched_files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,12 +36,12 @@ jobs:
         env:
           FORCE_COLOR: "1"
       - name: Build collection
-        run: ansible-galaxy collection build --output-path catalystcloud-distil.tar.gz
+        run: ansible-galaxy collection build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: build
-          path: catalystcloud-distil.tar.gz
+          path: catalystcloud-distil-*.tar.gz
           retention-days: 5
 
   molecule:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,22 +20,33 @@ jobs:
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
 
-  # ansible-galaxy:
-  #   runs-on: ubuntu-22.04
-  #   needs: pre-commit
-  #   steps:
-  #     - name: Checkout release
-  #       uses: actions/checkout@v4
-  #     - name: Test Ansible Galaxy collection build
-  #       uses: artis3n/ansible_galaxy_collection@v2
-  #       with:
-  #         api_key: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
-  #         publish: false
+  build:
+    runs-on: ubuntu-22.04
+    needs: pre-commit
+    steps:
+      - name: Checkout release
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Install pipeline Python packages
+        run: python -m pip install -r requirements.txt
+        env:
+          FORCE_COLOR: "1"
+      - name: Build collection
+        run: ansible-galaxy collection build --output-path catalystcloud-distil.tar.gz
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: catalystcloud-distil.tar.gz
+          retention-days: 5
 
   molecule:
     runs-on: ubuntu-22.04
-    needs: pre-commit
-    # needs: ansible-galaxy
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -55,7 +66,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: pip
-      - name: Install Python packages used for testing
+      - name: Install pipeline Python packages
         run: python -m pip install -r requirements.txt
         env:
           FORCE_COLOR: "1"


### PR DESCRIPTION
* Add a GitHub Actions workflow for automatically publishing a GitHub release containing release notes and the built collection ZIP file, when a tag is created.
* Add a job for building the collection in the test workflow, to make sure the collection can be built before merging.